### PR TITLE
Hide the progress bar when disabled

### DIFF
--- a/src/vpmApp/vpmAppDisplay/FapModesAnimation.C
+++ b/src/vpmApp/vpmAppDisplay/FapModesAnimation.C
@@ -96,16 +96,19 @@ bool FapAnimationCreator::modesAnimation (FmAnimation* animation,
   const double scale = animation->eigenmodeAmplitude.getValue();
   const double epssq = 1.0e-8;
 
-  FFaMsg::setSubTask("Creating Frames");
-  FFaMsg::enableProgress(100);
-
   if (modeType == FmAnimation::SYSTEM_MODES)
     FmDB::getAllOfType(links,FmLink::getClassTypeID());
 
+  FFaMsg::setSubTask("Creating Frames");
+  FFaMsg::enableProgress(links.size());
+
   // Loop over all links in the model
-  for (size_t i = 0; i < links.size(); i++)
+  int count = 0;
+  for (FmModelMemberBase* obj : links)
   {
-    FmLink* link = static_cast<FmLink*>(links[i]);
+    FFaMsg::setProgress(++count);
+
+    FmLink* link = static_cast<FmLink*>(obj);
     if (link->isSuppressed()) continue; // skip suppressed links
 
     linkPos = link->getGlobalCS();
@@ -154,8 +157,8 @@ bool FapAnimationCreator::modesAnimation (FmAnimation* animation,
     //////////////////////////////////////////////////////////////////
 
     // Get position matrix of current link
-    baseId = link->getBaseID();
-    FmPart* part = dynamic_cast<FmPart*>(link);
+    baseId = obj->getBaseID();
+    FmPart* part = dynamic_cast<FmPart*>(obj);
     const char* typeName = part ? "Part" : "Beam";
     getPosition(rdb,typeName,baseId,linkPos);
 #ifdef FAP_DEBUG
@@ -288,8 +291,6 @@ bool FapAnimationCreator::modesAnimation (FmAnimation* animation,
           visMod->setResultDeformation(frameId,vtxFrame);
 #endif
         }
-
-        FFaMsg::setProgress(100*i/links.size());
         continue; // go on with the next part
       }
       else
@@ -350,8 +351,6 @@ bool FapAnimationCreator::modesAnimation (FmAnimation* animation,
       fdlink->getVisualModel()->setResultTransform(frameId,curPos);
 #endif
     }
-
-    FFaMsg::setProgress(100.0*i/links.size());
   }
 
 

--- a/src/vpmPM/FpPM.C
+++ b/src/vpmPM/FpPM.C
@@ -939,10 +939,7 @@ bool FpPM::vpmModelOpen(const std::string& givenName, bool doLoadParts,
 
   // Create the visualization of the mechanism and show it
   FFaMsg::pushStatus("Creating visualization");
-  FFaMsg::enableSubSteps(FmDB::getObjectCount(FmPart::getClassTypeID()));
   FmDB::displayAll();
-  FFaMsg::disableSubSteps();
-  FFaMsg::setSubTask("");
   FFaMsg::popStatus();
 
 #ifdef FT_USE_PROFILER
@@ -1048,10 +1045,7 @@ bool FpPM::vpmAssemblyOpen(const std::string& givenName, bool doLoadParts)
 
   // Create the visualization of the mechanism and show it
   FFaMsg::pushStatus("Creating visualization");
-  FFaMsg::enableSubSteps(allParts.size());
   FmDB::displayAll(*newAss->getHeadMap());
-  FFaMsg::disableSubSteps();
-  FFaMsg::setSubTask("");
   FFaMsg::popStatus();
 
   // Update the object browser
@@ -1216,7 +1210,6 @@ bool FpPM::openTemplateFile(const std::string& modelPath)
 
   FFaMsg::pushStatus("Creating visualization");
   FmDB::displayAll();
-  FFaMsg::setSubTask("");
   FFaMsg::popStatus();
 
   FpPM::unTouchModel();
@@ -1708,10 +1701,7 @@ bool FpPM::vpmModelSaveAs(const std::string& name, bool saveReducedParts,
     {
       ListUI <<"  -> Model successfully updated with the state at time = "<< atTime <<"\n";
       FFaMsg::pushStatus("Update visualization");
-      FFaMsg::enableSubSteps(FmDB::getObjectCount(FmPart::getClassTypeID()));
       FmDB::displayAll();
-      FFaMsg::disableSubSteps();
-      FFaMsg::setSubTask("");
       FFaMsg::popStatus();
     }
   }

--- a/src/vpmUI/vpmUITopLevels/vpmUIQtTopLevels/FuiQtMainWindow.C
+++ b/src/vpmUI/vpmUITopLevels/vpmUIQtTopLevels/FuiQtMainWindow.C
@@ -101,7 +101,8 @@ FuiQtMainWindow::FuiQtMainWindow()
   this->QMainWindow::statusBar()->addWidget(this->mySubTaskLabel,3);
 
   this->myProgBar = new QProgressBar(this->QMainWindow::statusBar());
-  this->QMainWindow::statusBar()->addWidget(myProgBar,10);
+  this->QMainWindow::statusBar()->addWidget(this->myProgBar,10);
+  this->myProgBar->hide();
 
   FFuQtSplitter* items_ws__props = new FFuQtSplitter(Qt::Vertical,this);
   FFuQtSplitter* items__ws       = new FFuQtSplitter(Qt::Horizontal,items_ws__props);
@@ -208,19 +209,21 @@ void FuiQtMainWindow::clearStatusBarMessage()
 
 void FuiQtMainWindow::enableProgress(int steps)
 {
-  if (myProgBar) myProgBar->setMaximum(steps);
+  myProgBar->show();
+  myProgBar->setMaximum(steps);
 }
 //----------------------------------------------------------------------------
 
 void FuiQtMainWindow::setProgress(int step)
 {
-  if (myProgBar) myProgBar->setValue(step);
+  myProgBar->setValue(step);
 }
 //----------------------------------------------------------------------------
 
 void FuiQtMainWindow::disableProgress()
 {
-  if (myProgBar) myProgBar->reset();
+  myProgBar->reset();
+  myProgBar->hide();
 }
 //----------------------------------------------------------------------------
 
@@ -249,6 +252,7 @@ void FuiQtMainWindow::setSubStep(int step)
 
 void FuiQtMainWindow::disableSubSteps()
 {
+  mySubStepCount = 0;
   mySubStepLabel->setText("");
   mySubStepLabel->repaint();
 }


### PR DESCRIPTION
When the latest GUI is started, the green progress bar is always showing, indicating it is doing something.

Also consume the Nastran parser bugfix by consuming the submodule updates.