### PR TITLE
Adjust spacing in the Scale and Shift widget of the Curve property panel

### DIFF
--- a/src/vpmUI/vpmUIComponents/FuiScaleShiftWidget.C
+++ b/src/vpmUI/vpmUIComponents/FuiScaleShiftWidget.C
@@ -17,14 +17,6 @@ FuiScaleShiftWidget::FuiScaleShiftWidget() : readingDBonly(false)
 }
 
 
-void FuiScaleShiftWidget::setSensitivity(bool isSensitive)
-{
-  scaleField->setSensitivity(isSensitive);
-  shiftField->setSensitivity(isSensitive);
-  zeroOutBtn->setSensitivity(isSensitive);
-}
-
-
 void FuiScaleShiftWidget::getValues(double& scale, bool& onOff, double& shift)
 {
   scale = scaleField->getDouble();

--- a/src/vpmUI/vpmUIComponents/FuiScaleShiftWidget.H
+++ b/src/vpmUI/vpmUIComponents/FuiScaleShiftWidget.H
@@ -22,7 +22,6 @@ public:
   virtual ~FuiScaleShiftWidget() {}
 
   virtual void setFrameTitles(const char* main, const char* shift) = 0;
-  virtual void setSensitivity(bool isSensitive);
 
   void getValues(double& scale, bool& onOff, double& shift);
   void setValues(double  scale, bool  onOff, double  shift);

--- a/src/vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtScaleShiftWidget.C
+++ b/src/vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtScaleShiftWidget.C
@@ -36,7 +36,8 @@ FuiQtScaleShiftWidget::FuiQtScaleShiftWidget(QWidget* parent, const char* name)
   superFrame->setGeometry(0,0,295,122);
   QVBoxLayout* superFrameLayout = new QVBoxLayout(superFrame);
   superFrameLayout->setAlignment(Qt::AlignTop);
-  superFrameLayout->setSpacing(2);
+  superFrameLayout->setSpacing(5);
+  superFrameLayout->setContentsMargins(5,5,5,5);
 
   QHBoxLayout* layout = new QHBoxLayout();
   layout->addWidget(new QLabel("Scale",superFrame));
@@ -53,6 +54,7 @@ FuiQtScaleShiftWidget::FuiQtScaleShiftWidget(QWidget* parent, const char* name)
   QVBoxLayout* shiftFrameLayout = new QVBoxLayout(shiftFrame);
   shiftFrameLayout->setAlignment(Qt::AlignTop);
   shiftFrameLayout->setSpacing(2);
+  shiftFrameLayout->setContentsMargins(5,2,5,4);
 
   FFuQtToggleButton* qBtn;
   zeroOutBtn = qBtn = new FFuQtToggleButton(shiftFrame);

--- a/src/vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtScaleShiftWidget.H
+++ b/src/vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtScaleShiftWidget.H
@@ -30,11 +30,10 @@ class FuiQtScaleShiftWidget : public FFuQtMultUIComponent,
   Q_OBJECT
 
 public:
-  FuiQtScaleShiftWidget(QWidget* parent, const char* name = "FuiQtScaleShiftWidget");
+  FuiQtScaleShiftWidget(QWidget* parent, const char* name);
   virtual ~FuiQtScaleShiftWidget() {}
 
   virtual void setFrameTitles(const char* main, const char* shift);
-  virtual void setSensitivity(bool s) { this->FuiScaleShiftWidget::setSensitivity(s); }
 
 private slots:
   void btnToggled(bool);


### PR DESCRIPTION
After the Qt4-porting (from Qt3Support) in version R7.6, this widget has been malformed with too large spacing and too small data fields. This will fix it.