### PR TITLE
Listview updates

### DIFF
--- a/src/FFuLib/FFuListView.C
+++ b/src/FFuLib/FFuListView.C
@@ -5,8 +5,6 @@
 // This file is part of FEDEM - https://openfedem.org
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <iostream>
-
 #include "FFuLib/FFuListView.H"
 #include "FFuLib/FFuListViewItem.H"
 #include "FFuLib/FFuPopUpMenu.H"
@@ -18,7 +16,6 @@ FFuListView::FFuListView()
 {
   this->popUpMenu = NULL;
   this->tmpSelected = NULL;
-  this->ensureVisOnExpansion = true;
 }
 //----------------------------------------------------------------------------
 
@@ -27,18 +24,24 @@ void FFuListView::permTotSelectListItems(const std::vector<FFuListViewItem*>& to
   this->clearListSelection(notify);
   
   if (this->isSglSelectionMode() && totalSel.size() > 1)
-    std::cerr <<"WARNING - FFuListView::permTotSelectListItems: You are trying to select "
-              << totalSel.size() <<" items in single-selection mode"<< std::endl;
+  {
+    // This may happen happen if multiple items are selected in a list view
+    // allowing for it, also are present in another view which only allow
+    // single selection. In that case, select only the first item.
+    this->permSelectListItem(totalSel.front(),true,notify);
+  }
+  else
+  {
+    if (this->tmpSelected)
+      this->permSelectedDuringTmpSelection = totalSel;
 
-  if (this->tmpSelected)
-    this->permSelectedDuringTmpSelection = totalSel;
-
-  for (FFuListViewItem* item : totalSel)
-    this->permSelectListItem(item,true,notify);
+    for (FFuListViewItem* item : totalSel)
+      this->permSelectListItem(item,true,notify);
+  }
 }
 //----------------------------------------------------------------------------
 
-std::vector<FFuListViewItem*> FFuListView::getSelectedListItems()
+std::vector<FFuListViewItem*> FFuListView::getSelectedListItems() const
 {
   std::vector<FFuListViewItem*> items;
   for (const std::pair<const int,FFuListViewItem*>& lvi : this->lviMap)
@@ -49,7 +52,8 @@ std::vector<FFuListViewItem*> FFuListView::getSelectedListItems()
 }
 //----------------------------------------------------------------------------
 
-FFuListViewItem* FFuListView::getListItemBefore(FFuListViewItem* itemsParent,int itemsListPosition)
+FFuListViewItem* FFuListView::getListItemBefore(FFuListViewItem* itemsParent,
+                                                int itemsListPosition) const
 {
   if (itemsListPosition < 1) return NULL;
     
@@ -92,7 +96,7 @@ std::vector<FFuListViewItem*> FFuListView::getListChildren(FFuListViewItem* pare
 }
 //----------------------------------------------------------------------------
 
-std::vector<FFuListViewItem*> FFuListView::getAllListChildren(FFuListViewItem* parent)
+std::vector<FFuListViewItem*> FFuListView::getAllListChildren(FFuListViewItem* parent) const
 {
   std::vector<FFuListViewItem*> items;
 
@@ -121,7 +125,7 @@ std::vector<FFuListViewItem*> FFuListView::getAllListChildren(FFuListViewItem* p
 }
 //----------------------------------------------------------------------------
 
-FFuListViewItem* FFuListView::getListItem(int itemId)
+FFuListViewItem* FFuListView::getListItem(int itemId) const
 {
   if (itemId < 0) return NULL;
 
@@ -130,7 +134,7 @@ FFuListViewItem* FFuListView::getListItem(int itemId)
 }
 //----------------------------------------------------------------------------
 
-std::vector<FFuListViewItem*> FFuListView::arePresent(const std::vector<FFuListViewItem*>& in)
+std::vector<FFuListViewItem*> FFuListView::arePresent(const std::vector<FFuListViewItem*>& in) const
 {
   std::vector<FFuListViewItem*> present;
 
@@ -250,10 +254,6 @@ void FFuListView::onMenuItemSelected(const std::vector<FFuListViewItem*>& listIt
 
 void FFuListView::onListItemOpened(FFuListViewItem* listItem,bool open)
 {
-  if (this->ensureVisOnExpansion && open) {
-    //her kommer kode naar qt klarer dette bedre
-  }
-  
   this->listItemOpenedEvent(listItem,open); 
   this->invokeItemExpandedCB(listItem,open); 
 }

--- a/src/FFuLib/FFuListView.C
+++ b/src/FFuLib/FFuListView.C
@@ -167,69 +167,6 @@ void FFuListView::deleteListItem(FFuListViewItem* item)
 }
 //----------------------------------------------------------------------------
 
-FFuListViewItem* FFuListView::copyListItem(FFuListViewItem* itemToCopy,FFuListViewItem* copyToParent,
-					   FFuListViewItem* copyToAfter,bool copyIndices)
-{
-  FFuListViewItem *item, *newTopItem, *newItem, *newParent, *newAfter;
-
-  newItem = this->createListItem(copyToParent,copyToAfter,itemToCopy);
-  // copy index
-  if (copyIndices)
-    newItem->setItemId(itemToCopy->getItemId());
-
-  newTopItem = newItem;
-  newParent = newItem;
-  newAfter = NULL;
-  
-  //traversing the tree
-  item = itemToCopy->getFirstChildItem();
-  while (item) {
-    // creating new item
-    newItem = this->createListItem(newParent,newAfter,item);
-    // copy index
-    if (copyIndices)
-      newItem->setItemId(item->getItemId());
-
-    if (item->getFirstChildItem()) {
-      newParent = newItem;
-      newAfter = NULL;
-      item = item->getFirstChildItem();
-    }
-    else if (item->getNextSiblingItem()) {
-      newAfter = newItem;
-      item = item->getNextSiblingItem();
-    }
-    else { 
-      //rewind upwards till we find a sibling or we are itemToCopy
-      do {
-	item = item->getParentItem();
-	newItem = newItem->getParentItem();
-      } while (item && item != itemToCopy && !item->getNextSiblingItem());
-      if (item == itemToCopy)
-        break; // we are itemToCopy
-      else if (item) {
-	//first sibling on the way up
-	newParent = newItem->getParentItem();
-	newAfter = newItem;
-	item = item->getNextSiblingItem();
-      }
-    }
-  }
-  return newTopItem;
-}
-//----------------------------------------------------------------------------
-
-FFuListViewItem* FFuListView::moveListItem(FFuListViewItem* itemToMove,FFuListViewItem* moveToParent,
-					   FFuListViewItem* moveToAfter)
-{
-  FFuListViewItem* newTopItem = this->copyListItem(itemToMove,moveToParent,moveToAfter,true);
-  if (!newTopItem) return NULL;
-
-  this->deleteListItem(itemToMove);
-  return newTopItem;
-}
-//----------------------------------------------------------------------------
-
 void FFuListView::onPermSelectionChanged()
 { 
   this->permSelectionChangedEvent();

--- a/src/FFuLib/FFuListView.C
+++ b/src/FFuLib/FFuListView.C
@@ -19,7 +19,7 @@ FFuListView::FFuListView()
 }
 //----------------------------------------------------------------------------
 
-void FFuListView::permTotSelectListItems(const std::vector<FFuListViewItem*>& totalSel, bool notify)
+void FFuListView::permTotSelectListItems(const FFuListViewItems& totalSel, bool notify)
 {
   this->clearListSelection(notify);
   
@@ -41,9 +41,9 @@ void FFuListView::permTotSelectListItems(const std::vector<FFuListViewItem*>& to
 }
 //----------------------------------------------------------------------------
 
-std::vector<FFuListViewItem*> FFuListView::getSelectedListItems() const
+FFuListViewItems FFuListView::getSelectedListItems() const
 {
-  std::vector<FFuListViewItem*> items;
+  FFuListViewItems items;
   for (const std::pair<const int,FFuListViewItem*>& lvi : this->lviMap)
     if (lvi.second->isItemSelected())
       items.push_back(lvi.second);
@@ -77,9 +77,9 @@ FFuListViewItem* FFuListView::getListItemBefore(FFuListViewItem* itemsParent,
 }
 //----------------------------------------------------------------------------
 
-std::vector<FFuListViewItem*> FFuListView::getListChildren(FFuListViewItem* parent)
+FFuListViewItems FFuListView::getListChildren(FFuListViewItem* parent)
 {
-  std::vector<FFuListViewItem*> items;
+  FFuListViewItems items;
   FFuListViewItem* item;
 
   if (parent)
@@ -96,9 +96,9 @@ std::vector<FFuListViewItem*> FFuListView::getListChildren(FFuListViewItem* pare
 }
 //----------------------------------------------------------------------------
 
-std::vector<FFuListViewItem*> FFuListView::getAllListChildren(FFuListViewItem* parent) const
+FFuListViewItems FFuListView::getAllListChildren(FFuListViewItem* parent) const
 {
-  std::vector<FFuListViewItem*> items;
+  FFuListViewItems items;
 
   if (!parent)
     for (const std::pair<const int,FFuListViewItem*>& lvi : this->lviMap)
@@ -134,9 +134,9 @@ FFuListViewItem* FFuListView::getListItem(int itemId) const
 }
 //----------------------------------------------------------------------------
 
-std::vector<FFuListViewItem*> FFuListView::arePresent(const std::vector<FFuListViewItem*>& in) const
+FFuListViewItems FFuListView::arePresent(const FFuListViewItems& in) const
 {
-  std::vector<FFuListViewItem*> present;
+  FFuListViewItems present;
 
   for (FFuListViewItem* item : in)
     for (const std::pair<const int,FFuListViewItem*>& lvi : this->lviMap)
@@ -170,43 +170,43 @@ void FFuListView::deleteListItem(FFuListViewItem* item)
 void FFuListView::onPermSelectionChanged()
 { 
   this->permSelectionChangedEvent();
-  this->invokePermSelectionChangedCB();
+  this->permSelectionChangedCB.invoke();
 }
 //----------------------------------------------------------------------------
 
 void FFuListView::onTmpSelectionChanged(FFuListViewItem* listItem)
 { 
   this->tmpSelectionChangedEvent(listItem);
-  this->invokeTmpSelectionChangedCB(listItem);
+  this->tmpSelectionChangedCB.invoke(listItem);
 }
 //----------------------------------------------------------------------------
 
-void FFuListView::onMenuItemSelected(const std::vector<FFuListViewItem*>& listItems,
+void FFuListView::onMenuItemSelected(const FFuListViewItems& listItems,
 				     FFuaCmdItem* menuItem)
 {
   this->menuItemSelectedEvent(listItems,menuItem);
-  this->invokeMenuItemSelectedCB(listItems,menuItem);
+  this->menuItemSelectedCB.invoke(listItems,menuItem);
 }
 //----------------------------------------------------------------------------
 
 void FFuListView::onListItemOpened(FFuListViewItem* listItem,bool open)
 {
-  this->listItemOpenedEvent(listItem,open); 
-  this->invokeItemExpandedCB(listItem,open); 
+  this->listItemOpenedEvent(listItem,open);
+  this->itemExpandedCB.invoke(listItem,open);
 }
 //----------------------------------------------------------------------------
 
 void FFuListView::onListItemToggled(FFuListViewItem* listItem,int toggle)
 {
   this->listItemToggledEvent(listItem,toggle);
-  this->invokeItemToggledCB(listItem,toggle); 
+  this->itemToggledCB.invoke(listItem,toggle);
 }
 //----------------------------------------------------------------------------
 
 void FFuListView::executePopUp(FFuListViewItem* rMBItem)
 {
   FFuaCmdItem* id = NULL;
-  std::vector<FFuListViewItem*> realSelected = this->getSelectedListItems();
+  FFuListViewItems realSelected = this->getSelectedListItems();
   if (rMBItem) {
     if (rMBItem->isItemSelected()) {
       this->rightMousePressed(rMBItem);
@@ -226,7 +226,7 @@ void FFuListView::executePopUp(FFuListViewItem* rMBItem)
     if (!this->popUpMenu->isMenuEmpty())
       id = this->popUpMenu->executeAtCursorPos();
     if (id && !this->menuItemSelectedCB.empty())
-      this->onMenuItemSelected(std::vector<FFuListViewItem*>(),id);
+      this->onMenuItemSelected({},id);
   }
 }
 //----------------------------------------------------------------------------
@@ -236,7 +236,7 @@ void FFuListView::tmpSelectListItem(FFuListViewItem* item, bool)
   if (!item || item == this->tmpSelected)
     return;
 
-  std::vector<FFuListViewItem*> realSelected = this->getSelectedListItems();
+  FFuListViewItems realSelected = this->getSelectedListItems();
 
   this->onTmpSelectionChanged(item);
   this->permTotSelectListItems({item});

--- a/src/FFuLib/FFuListView.H
+++ b/src/FFuLib/FFuListView.H
@@ -100,6 +100,7 @@ public:
   virtual void setListColumns(const std::vector<const char*>& labels) = 0;
   // sets the width mode to MANUAL for this column, default is MAXIMUM
   virtual void setListColumnWidth(int column, int width) = 0;
+  virtual void resizeListColumnsToContents() = 0;
 
   // The notify setting is loyal to FFuComponentBase::blockNotification
   // In single sel mode this method touches other items selection, in other modes it does not.
@@ -122,9 +123,6 @@ public:
   std::vector<FFuListViewItem*> getListChildren(FFuListViewItem* parent);//ordered in lv order 
   //all levels below parent, if parent = 0 all lv
   std::vector<FFuListViewItem*> getAllListChildren(FFuListViewItem* parent);//ordered in lv order 
-
-  virtual bool isExpanded(FFuListViewItem* item) = 0;
-  virtual int getNColumns() = 0;
 
   FFuListViewItem* getListItem(int itemId);
 

--- a/src/FFuLib/FFuListView.H
+++ b/src/FFuLib/FFuListView.H
@@ -18,9 +18,13 @@ class FFuListViewItem;
 class FFuPopUpMenu;
 class FFuaCmdItem;
 
+using FFuListViewItems = std::vector<FFuListViewItem*>; //!< Convenience alias
+
 
 /*!
-  The list view items are given an unique id (>-1) when created.
+  \brief Base class for various list views in FEDEM.
+
+  \details The list view items are given an unique id (>-1) when created.
   This id is meant to serve as an identifier for external bookkeeping.
   Never bookkeep the item pointers as they may change during manipulation.
   Nevertheless, most manipulation methods are based on pointers since that
@@ -29,7 +33,7 @@ class FFuaCmdItem;
   The notification philosophy is to notify only under direct user-interaction
   You can override this for some cases by setting the notify argument to true
 
-  The listview disables sorting as default.
+  The list view disables sorting as default.
   Single selection mode is default.
 
   Known bugs: Headerclick disabling doesn't work for frenetic clicking.
@@ -50,8 +54,7 @@ public:
     {this->permSelectionChangedCB = aDynCB;}
   void setTmpSelectionChangedCB(const FFaDynCB1<FFuListViewItem*>& aDynCB)
     {this->tmpSelectionChangedCB = aDynCB;}
-  void setMenuItemSelectedCB(const FFaDynCB2<const std::vector<FFuListViewItem*>&,
-			     FFuaCmdItem*>& aDynCB) 
+  void setMenuItemSelectedCB(const FFaDynCB2<const FFuListViewItems&,FFuaCmdItem*>& aDynCB)
     {this->menuItemSelectedCB = aDynCB;}
   void setItemExpandedCB(const FFaDynCB2<FFuListViewItem*,bool>& aDynCB)
     {this->itemExpandedCB = aDynCB;} 
@@ -69,6 +72,8 @@ public:
   //FFuListViewItem* is selected when this cb is emitted
   void setRightMouseBPressCB(const FFaDynCB1<FFuListViewItem*>& aDynCB)
     {this->rMouseBPressedCB = aDynCB;}
+  void setHeaderClickedCB(const FFaDynCB1<int>& aDynCB)
+    {this->headerClickedCB = aDynCB;}
  
   // LIST SETTINGS
   
@@ -102,7 +107,7 @@ public:
   // The notify setting is loyal to FFuComponentBase::blockNotification
   // In single sel mode this method touches other items selection, in other modes it does not.
   virtual void permSelectListItem(FFuListViewItem* item,bool select=true,bool notify=false)=0; 
-  void permTotSelectListItems(const std::vector<FFuListViewItem*>& totalSel, bool notify=false);
+  void permTotSelectListItems(const FFuListViewItems& totalSel, bool notify=false);
   void tmpSelectListItem(FFuListViewItem* item,bool notify=false); 
   virtual void clearListSelection(bool notify=false)=0; 
   virtual void openListItem(FFuListViewItem* item,bool open,bool notify=false)=0;
@@ -112,18 +117,18 @@ public:
   // Current item is the one with keyboard focus, selected item is the highlighted.
   // Current item differentiates the items under multiselection mode.
   
-  std::vector<FFuListViewItem*> getSelectedListItems() const;
+  FFuListViewItems getSelectedListItems() const;
   virtual FFuListViewItem* getSelectedListItemSglMode() const = 0;
   virtual FFuListViewItem* getCurrentListItem() const = 0;
   virtual FFuListViewItem* getFirstChildItem() const = 0;
   FFuListViewItem* getListItemBefore(FFuListViewItem* itemsParent, int itemsListPosition) const;
-  std::vector<FFuListViewItem*> getListChildren(FFuListViewItem* parent);//ordered in lv order 
+  FFuListViewItems getListChildren(FFuListViewItem* parent); //ordered in lv order
   //all levels below parent, if parent = 0 all lv
-  std::vector<FFuListViewItem*> getAllListChildren(FFuListViewItem* parent) const;//ordered in lv order
+  FFuListViewItems getAllListChildren(FFuListViewItem* parent) const; //ordered in lv order
 
   FFuListViewItem* getListItem(int itemId) const;
 
-  std::vector<FFuListViewItem*> arePresent(const std::vector<FFuListViewItem*>& in) const;
+  FFuListViewItems arePresent(const FFuListViewItems& in) const;
 
   // LIST MANIPULATION
  
@@ -140,26 +145,23 @@ public:
 
 protected:
   //slots
-  void onPermSelectionChanged();		
+  void onPermSelectionChanged();
   void onTmpSelectionChanged(FFuListViewItem* listItem);
-  void onMenuItemSelected(const std::vector<FFuListViewItem*>& listItems,
-			  FFuaCmdItem* menuItem);		
-  void onListItemOpened(FFuListViewItem* listItem,bool open);
+  void onMenuItemSelected(const FFuListViewItems& items, FFuaCmdItem* mItem);
+  void onListItemOpened(FFuListViewItem* listItem, bool open);
 public:
-  void onListItemToggled(FFuListViewItem* listItem,int toggle);
+  void onListItemToggled(FFuListViewItem* listItem, int toggle);
 
 protected:  
   //RE-IMPLs
   //These can be reimpl in subclass
-  virtual void permSelectionChangedEvent() {}		
+  virtual void permSelectionChangedEvent() {}
   virtual void tmpSelectionChangedEvent(FFuListViewItem*) {}
-  virtual void menuItemSelectedEvent(const std::vector<FFuListViewItem*>&, FFuaCmdItem*) {}
+  virtual void menuItemSelectedEvent(const FFuListViewItems&, FFuaCmdItem*) {}
   virtual void listItemOpenedEvent(FFuListViewItem*,bool) {}
   virtual void listItemToggledEvent(FFuListViewItem*,int) {}
   virtual void rightMousePressed(FFuListViewItem*) {}
 
-protected:  
-  
   // These methodes are called every time a lv pops up/down, also
   // from an iconified position
   virtual void onPoppedUp() {}
@@ -170,44 +172,18 @@ protected:
   virtual void onPoppedUpFromMem() {}
   // called when a ui is on its way to the memory (hide)
   virtual void onPoppedDownToMem() {}
-  
-
-protected:
-  void invokePermSelectionChangedCB() 
-    {this->permSelectionChangedCB.invoke();}
-  void invokeTmpSelectionChangedCB(FFuListViewItem* listItem) 
-    {this->tmpSelectionChangedCB.invoke(listItem);}
-  void invokeMenuItemSelectedCB(const std::vector<FFuListViewItem*>& listItems,
-				FFuaCmdItem* menuItem)
-    {this->menuItemSelectedCB.invoke(listItems,menuItem);}
-  void invokeItemExpandedCB(FFuListViewItem* item,bool open)
-    {this->itemExpandedCB.invoke(item,open);}
-  void invokeItemToggledCB(FFuListViewItem* item,int toggle)
-    {this->itemToggledCB.invoke(item,toggle);}
-  void invokeDoubleClickedCB(FFuListViewItem* listItem) 
-    {this->doubleClickedCB.invoke(listItem);}
-  void invokeReturnPressedCB(FFuListViewItem* listItem)
-    {this->returnPressedCB.invoke(listItem);}
-  void invokeLeftMouseBPressedCB(FFuListViewItem* listItem)
-    {this->lMouseBPressedCB.invoke(listItem);}
-  void invokeLeftMouseBReleaseCB()
-    {this->lMouseBReleaseCB.invoke();}
-  void invokeRightMouseBPressedCB(FFuListViewItem* listItem)
-    {this->rMouseBPressedCB.invoke(listItem);}
 
   void executePopUp(FFuListViewItem* listItem);
 
 protected:
   // Component "shadow" members
-  FFuPopUpMenu* popUpMenu; 
-
+  FFuPopUpMenu*    popUpMenu;
   FFuListViewItem* tmpSelected;
-  std::vector<FFuListViewItem*> permSelectedDuringTmpSelection;
+  FFuListViewItems permSelectedDuringTmpSelection;
 
   std::map<int,FFuListViewItem*> lviMap;
 
-private:
-  // Internal CB objects :
+  // Internal call-back objects :
   FFaDynCB0                   permSelectionChangedCB;
   FFaDynCB1<FFuListViewItem*> tmpSelectionChangedCB;
   FFaDynCB2<FFuListViewItem*,bool> itemExpandedCB;
@@ -217,9 +193,9 @@ private:
   FFaDynCB1<FFuListViewItem*> lMouseBPressedCB;
   FFaDynCB0                   lMouseBReleaseCB;
   FFaDynCB1<FFuListViewItem*> rMouseBPressedCB;
+  FFaDynCB1<int>              headerClickedCB;
 
-  FFaDynCB2<const std::vector<FFuListViewItem*>&,FFuaCmdItem*> menuItemSelectedCB;
+  FFaDynCB2<const FFuListViewItems&,FFuaCmdItem*> menuItemSelectedCB;
 };
-/////////////////////////////////////////////////////////////////////////////
 
 #endif

--- a/src/FFuLib/FFuListView.H
+++ b/src/FFuLib/FFuListView.H
@@ -127,27 +127,13 @@ public:
 
   // LIST MANIPULATION
  
-  // The item gets default text in col 0 when created.
-  // If parent=0, the item is created at top level in the list view
-  // If after=0 the item is inserted first in parents list
-
-  virtual FFuListViewItem* createListItem(FFuListViewItem* parent=0,FFuListViewItem* after=0,
-					  FFuListViewItem* original=0,const char* label="item") = 0;
-  
+  // The item gets default text in column 0 when created.
+  // If parent is null, the item is created at top level in the list view
+  // If after is null the item is inserted first in parents list
+  virtual FFuListViewItem* createListItem(const char* label = NULL,
+                                          FFuListViewItem* parent = NULL,
+                                          FFuListViewItem* after = NULL) = 0;
   void deleteListItem(FFuListViewItem* item);
-
-  // Copies item and all children to desired position
-  // Return 0 if irregularities
-  FFuListViewItem* copyListItem(FFuListViewItem* itemToCopy,FFuListViewItem* copyToParent=0,
-				FFuListViewItem* copyToAfter=0,bool copyIndices=false);
-  
-  // Moves item and all children to desired position
-  // This method actually creates new items and therefore returns the new (parent) item's pointer, 
-  // but inherits the original's indices.  
-  // DO NEVER USE THE ITEM'S OLD POINTER AFTER A MOVEMENT.
-  // Return 0 if irregularities, autom unselect and unexpand
-  FFuListViewItem* moveListItem(FFuListViewItem* itemToMove,FFuListViewItem* moveToParent=0,
-				FFuListViewItem* moveToAfter=0);
   
   // POPUP MENU 
   FFuPopUpMenu* getPopUpMenu() const { return this->popUpMenu; }

--- a/src/FFuLib/FFuListView.H
+++ b/src/FFuLib/FFuListView.H
@@ -12,7 +12,6 @@
 #include "FFaLib/FFaDynCalls/FFaDynCB.H"
 
 #include <vector>
-#include <string>
 #include <map>
 
 class FFuListViewItem;
@@ -89,8 +88,6 @@ public:
   
   virtual void setSglSelectionMode(bool single) = 0;
   virtual bool isSglSelectionMode() const = 0;
-
-  void setEnsureVisibleOnExpansion(bool vis) {this->ensureVisOnExpansion = vis;}
   
 
   // BASIC LIST FUNCTION
@@ -115,18 +112,18 @@ public:
   // Current item is the one with keyboard focus, selected item is the highlighted.
   // Current item differentiates the items under multiselection mode.
   
-  std::vector<FFuListViewItem*> getSelectedListItems(); 
-  virtual FFuListViewItem* getSelectedListItemSglMode() = 0; 
-  virtual FFuListViewItem* getCurrentListItem()=0; 
-  virtual FFuListViewItem* getFirstChildItem() = 0; 
-  FFuListViewItem* getListItemBefore(FFuListViewItem* itemsParent,int itemsListPosition); 
+  std::vector<FFuListViewItem*> getSelectedListItems() const;
+  virtual FFuListViewItem* getSelectedListItemSglMode() const = 0;
+  virtual FFuListViewItem* getCurrentListItem() const = 0;
+  virtual FFuListViewItem* getFirstChildItem() const = 0;
+  FFuListViewItem* getListItemBefore(FFuListViewItem* itemsParent, int itemsListPosition) const;
   std::vector<FFuListViewItem*> getListChildren(FFuListViewItem* parent);//ordered in lv order 
   //all levels below parent, if parent = 0 all lv
-  std::vector<FFuListViewItem*> getAllListChildren(FFuListViewItem* parent);//ordered in lv order 
+  std::vector<FFuListViewItem*> getAllListChildren(FFuListViewItem* parent) const;//ordered in lv order
 
-  FFuListViewItem* getListItem(int itemId);
+  FFuListViewItem* getListItem(int itemId) const;
 
-  std::vector<FFuListViewItem*> arePresent(const std::vector<FFuListViewItem*>& in);
+  std::vector<FFuListViewItem*> arePresent(const std::vector<FFuListViewItem*>& in) const;
 
   // LIST MANIPULATION
  
@@ -153,7 +150,7 @@ public:
 				FFuListViewItem* moveToAfter=0);
   
   // POPUP MENU 
-  FFuPopUpMenu* getPopUpMenu() {return this->popUpMenu;}
+  FFuPopUpMenu* getPopUpMenu() const { return this->popUpMenu; }
 
 protected:
   //slots
@@ -214,15 +211,12 @@ protected:
 
   void executePopUp(FFuListViewItem* listItem);
 
-// Attributes
 protected:
   // Component "shadow" members
   FFuPopUpMenu* popUpMenu; 
 
   FFuListViewItem* tmpSelected;
   std::vector<FFuListViewItem*> permSelectedDuringTmpSelection;
-
-  bool ensureVisOnExpansion;
 
   std::map<int,FFuListViewItem*> lviMap;
 

--- a/src/FFuLib/FFuListViewItem.C
+++ b/src/FFuLib/FFuListViewItem.C
@@ -17,18 +17,13 @@ FFuListViewItem::FFuListViewItem()
 
   this->toggle = UNTOGGLED;
   this->toggleAble = false;
-  this->boldtext = false;
-  this->italictext = false;
 }
 //----------------------------------------------------------------------------
 
 void FFuListViewItem::copyData(FFuListViewItem* original)
 {
   this->copyPixmaps(original);
-  this->setItemTextBold(original->boldtext);
-  this->setItemTextItalic(original->italictext);
-  for (int i=0;i<this->getListView()->getNColumns();i++)
-    this->setItemText(i,original->getItemText(i).c_str());
+  this->copyTexts(original);
 
   if (original->toggleAble) {
     this->setItemToggleAble(original->toggleAble);

--- a/src/FFuLib/FFuListViewItem.C
+++ b/src/FFuLib/FFuListViewItem.C
@@ -20,18 +20,6 @@ FFuListViewItem::FFuListViewItem()
 }
 //----------------------------------------------------------------------------
 
-void FFuListViewItem::copyData(FFuListViewItem* original)
-{
-  this->copyPixmaps(original);
-  this->copyTexts(original);
-
-  if (original->toggleAble) {
-    this->setItemToggleAble(original->toggleAble);
-    this->setToggleValue(original->toggle);
-  }
-}
-//----------------------------------------------------------------------------
-
 FFuListViewItem* FFuListViewItem::getPreviousSiblingItem() const
 {
   FFuListViewItem* item = this->getParentItem();

--- a/src/FFuLib/FFuListViewItem.H
+++ b/src/FFuLib/FFuListViewItem.H
@@ -8,102 +8,86 @@
 #ifndef FFU_LIST_VIEW_ITEM_H
 #define FFU_LIST_VIEW_ITEM_H
 
-#include "FFaLib/FFaDynCalls/FFaDynCB.H"
+#include <string>
 
 class FFuListView;
 
 
 /*!
-  This class automatically sets an unique id (>-1) for the item. The id is
-  meant to serve as an identifier for external bookkeeping. Never bookkeep
-  the item pointers as they may change during item manipulation (QListView
-  is no good!).
+  This class automatically sets an unique id (>-1) for the item.
+  The id is meant to serve as an identifier for external bookkeeping.
+  Never bookkeep the item pointers as they may change during item manipulation.
 
   \author Dag R. Christensen
   \date Mar 5 1999
 */
 
-class FFuListViewItem 
+class FFuListViewItem
 {
 public:
   FFuListViewItem();
-  virtual ~FFuListViewItem();
-  
-  // Unique item identifier
-  int  getItemId()       { return this->itemId;}
-  void setItemId(int id) { this->itemId = id ; }
+  virtual ~FFuListViewItem() {}
 
+  // Unique item identifier
+  int  getItemId() const { return itemId; }
+  void setItemId(int id) { itemId = id; }
+
+protected:
   // Copy text/toggle etc, but not ID (this item is unique)
   void copyData(FFuListViewItem* original);
   virtual void copyPixmaps(FFuListViewItem* original)=0;
-  
+
+public:
   // Basic item functions
-  virtual void  setItemText(int col,const char* text)=0;
-  virtual char* getItemText(int col=0)=0;
+  virtual void        setItemText(int col, const char* text) = 0;
+  virtual std::string getItemText(int col) const = 0;
 
-  virtual void  setItemTextBold(bool bold=true)=0;
-  virtual void  setItemTextItalic(bool italic=true)=0;
+  virtual void setItemTextBold(int col, bool bold = true) = 0;
+  virtual void setItemTextItalic(int col, bool italic = true) = 0;
 
-  virtual void  setItemImage(int col,const char **pixmap)=0;
+  virtual void setItemImage(int col, const char** pixmap) = 0;
 
-  virtual bool  isItemSelected()= 0;
-
-  virtual int   getDepth()=0;
-
-  virtual void  setItemSelectable(bool enable)=0;
+  virtual void setItemSelectable(bool enable) = 0;
+  virtual bool isItemSelected() const = 0;
 
   // Relations
-  virtual FFuListView*     getListView()= 0;
-  virtual FFuListViewItem* getParentItem()= 0;
-  virtual FFuListViewItem* getFirstChildItem()= 0;
-  virtual FFuListViewItem* getLastChildItem()= 0;
-  virtual FFuListViewItem* getNextSiblingItem()= 0;
-          FFuListViewItem* getPreviousSiblingItem();
-  virtual int              getNSiblings() = 0;//with me included
-  virtual int              getNChildren() = 0;
-  int              getItemPosition();//starts with 0
-  
+  virtual FFuListView*     getListView() const = 0;
+  virtual FFuListViewItem* getParentItem() const = 0;
+  virtual FFuListViewItem* getFirstChildItem() const = 0;
+  virtual FFuListViewItem* getLastChildItem() const = 0;
+  virtual FFuListViewItem* getNextSiblingItem() const = 0;
+          FFuListViewItem* getPreviousSiblingItem() const;
+  virtual int              getNSiblings() const = 0; // with me included
+  virtual int              getNChildren() const = 0;
+
+  int getItemPosition() const; // starts with 0
+  int getDepth() const;
+
   virtual void setItemDropable(bool enable) = 0;
   virtual void setItemDragable(bool enable) = 0;
 
-
   // Levels
-  bool isFirstLevel(); // no parent 
-  bool isSecondLevel(); // no grandparent but parent 
-  bool isThirdLevel();  // no grand-grandparent but grandparent and parent 
-  
-  
+  bool isFirstLevel() const;  // no parent
+  bool isSecondLevel() const; // no grandparent but parent
+  bool isThirdLevel() const;  // no greatgrandparent but grandparent and parent
 
-  //Toggle
-  enum {UNTOGGLED,TOGGLED,HALFTOGGLED,NTOGGLES};//toggle
-  bool isItemToggleAble() {return this->toggleAble;}
+  // Toggle, status starts always on UNTOGGLED
+  enum ToggleVal { UNTOGGLED, TOGGLED, HALFTOGGLED };
+  bool isItemToggleAble() const { return toggleAble > 0; }
+  int getToggleValue() const { return toggle; }
 
-  //Togglestatus starts always on UNTOGGLED.
-  virtual void setItemToggleAble(bool able)=0;
-  void setItemThreeStepToggleAble(bool able) {
-    if (able) this->setItemToggleAble(able);
-    this->threeStepToggleAble = able;
-  }
-  virtual void setToggleValue(int toggle,bool notify=false)=0;
-  void toggleItem(bool notify=false);
-
-  int getToggleValue() {return this->toggle;}
+  virtual void setItemToggleAble(unsigned char able) = 0;
+  virtual void setToggleValue(int toggle, bool notify = false) = 0;
+  void toggleItem(bool notify = false);
+  void setItemThreeStepToggleAble(bool able);
 
 protected:
-  int itemId; 
-
-  bool toggleAble;
-  bool threeStepToggleAble;
+  int itemId;
   int toggle;
-  static const char** togglepx[NTOGGLES]; 
+  unsigned char toggleAble; // 0, 1 or 3=three-step-toggleble
 
   //itemtext manipulations
   bool boldtext,italictext;  
-
-  const char** col0Pixmap;
-
-private:
-  static int itemCount;
 };
 
 #endif

--- a/src/FFuLib/FFuListViewItem.H
+++ b/src/FFuLib/FFuListViewItem.H
@@ -32,13 +32,6 @@ public:
   int  getItemId() const { return itemId; }
   void setItemId(int id) { itemId = id; }
 
-protected:
-  // Copy text/toggle etc, but not ID (this item is unique)
-  void copyData(FFuListViewItem* original);
-  virtual void copyPixmaps(FFuListViewItem* original)=0;
-  virtual void copyTexts(FFuListViewItem* original)=0;
-
-public:
   // Basic item functions
   virtual void        setItemText(int col, const char* text) = 0;
   virtual std::string getItemText(int col) const = 0;

--- a/src/FFuLib/FFuListViewItem.H
+++ b/src/FFuLib/FFuListViewItem.H
@@ -36,6 +36,7 @@ protected:
   // Copy text/toggle etc, but not ID (this item is unique)
   void copyData(FFuListViewItem* original);
   virtual void copyPixmaps(FFuListViewItem* original)=0;
+  virtual void copyTexts(FFuListViewItem* original)=0;
 
 public:
   // Basic item functions
@@ -50,6 +51,8 @@ public:
   virtual void setItemSelectable(bool enable) = 0;
   virtual bool isItemSelected() const = 0;
 
+  virtual bool isItemExpanded() const = 0;
+
   // Relations
   virtual FFuListView*     getListView() const = 0;
   virtual FFuListViewItem* getParentItem() const = 0;
@@ -59,6 +62,7 @@ public:
           FFuListViewItem* getPreviousSiblingItem() const;
   virtual int              getNSiblings() const = 0; // with me included
   virtual int              getNChildren() const = 0;
+  virtual int              getNColumns() const = 0;
 
   int getItemPosition() const; // starts with 0
   int getDepth() const;
@@ -85,9 +89,6 @@ protected:
   int itemId;
   int toggle;
   unsigned char toggleAble; // 0, 1 or 3=three-step-toggleble
-
-  //itemtext manipulations
-  bool boldtext,italictext;  
 };
 
 #endif

--- a/src/FFuLib/FFuQtComponents/FFuQtListView.C
+++ b/src/FFuLib/FFuQtComponents/FFuQtListView.C
@@ -36,6 +36,9 @@ FFuQtListView::FFuQtListView(QWidget* parent, int nColumns, const char* name)
                    this, SLOT(fwdReturnPressed(QTreeWidgetItem*,int)));
   QObject::connect(this, SIGNAL(itemDoubleClicked(QTreeWidgetItem*,int)),
                    this, SLOT(fwdDoubleClicked(QTreeWidgetItem*,int)));
+
+  QObject::connect(this->header(), SIGNAL(sectionClicked(int)),
+                   this, SLOT(fwdHeaderClicked(int)));
 }
 //----------------------------------------------------------------------------
 
@@ -59,13 +62,19 @@ void FFuQtListView::fwdCollapsed(QTreeWidgetItem* item)
 
 void FFuQtListView::fwdReturnPressed(QTreeWidgetItem* item, int)
 {
-  this->invokeReturnPressedCB(dynamic_cast<FFuListViewItem*>(item));
+  returnPressedCB.invoke(dynamic_cast<FFuListViewItem*>(item));
 }
 //----------------------------------------------------------------------------
 
 void FFuQtListView::fwdDoubleClicked(QTreeWidgetItem* item, int)
 {
-  this->invokeDoubleClickedCB(dynamic_cast<FFuListViewItem*>(item));
+  doubleClickedCB.invoke(dynamic_cast<FFuListViewItem*>(item));
+}
+//----------------------------------------------------------------------------
+
+void FFuQtListView::fwdHeaderClicked(int col)
+{
+  headerClickedCB.invoke(col);
 }
 //----------------------------------------------------------------------------
 
@@ -355,11 +364,11 @@ void FFuQtListView::mousePressEvent(QMouseEvent* e)
       }
     }
 
-    this->invokeLeftMouseBPressedCB(item);
+    lMouseBPressedCB.invoke(item);
   }
   else if (e->button() & Qt::RightButton)
   {
-    this->invokeRightMouseBPressedCB(item);
+    rMouseBPressedCB.invoke(item);
     this->executePopUp(item);
   }
 
@@ -370,7 +379,7 @@ void FFuQtListView::mousePressEvent(QMouseEvent* e)
 void FFuQtListView::mouseReleaseEvent(QMouseEvent* e)
 {
   if (e->button() & Qt::LeftButton)
-    this->invokeLeftMouseBReleaseCB();
+    lMouseBReleaseCB.invoke();
 
   this->QTreeWidget::mouseReleaseEvent(e);
 }

--- a/src/FFuLib/FFuQtComponents/FFuQtListView.C
+++ b/src/FFuLib/FFuQtComponents/FFuQtListView.C
@@ -24,6 +24,11 @@ FFuQtListView::FFuQtListView(QWidget* parent, int nColumns, const char* name)
   this->setListSorting(-1,true); // disable sorting
   this->setAllListColumnsShowSelection(true);
 
+  // Somehow this is neeeded to set the proper font size
+  QFont f = this->font();
+  f.setPointSize(f.pointSize());
+  this->setFont(f);
+
   this->popUpMenu = new FFuQtPopUpMenu(this);
 
   QObject::connect(this, SIGNAL(itemSelectionChanged()),

--- a/src/FFuLib/FFuQtComponents/FFuQtListView.C
+++ b/src/FFuLib/FFuQtComponents/FFuQtListView.C
@@ -5,7 +5,7 @@
 // This file is part of FEDEM - https://openfedem.org
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <Qt3Support/Q3Header>
+#include <QHeaderView>
 #include <QMouseEvent>
 
 #include "FFuLib/FFuQtComponents/FFuQtListViewItem.H"
@@ -15,32 +15,27 @@
 //----------------------------------------------------------------------------
 
 FFuQtListView::FFuQtListView(QWidget* parent, int nColumns, const char* name)
-  : Q3ListView(parent)
+  : QTreeWidget(parent)
 {
-  this->setObjectName(name);
   this->setWidget(this);
-
-  for (int c = 0; c < nColumns; c++)
-    this->addColumn("empty");
+  this->setColumnCount(nColumns);
+  this->setObjectName(name);
+  this->setSglSelectionMode(true);
+  this->setListSorting(-1,true); // disable sorting
+  this->setAllListColumnsShowSelection(true);
 
   this->popUpMenu = new FFuQtPopUpMenu(this);
 
-#ifndef linux
-  this->setSglSelectionMode(true);
-  this->setListSorting(-1); // disable sorting
-  this->setAllListColumnsShowSelection(true);
-#endif
-
-  QObject::connect(this,SIGNAL(selectionChanged()),
-		   this,SLOT(fwdSelectionChanged()));
-  QObject::connect(this,SIGNAL(expanded(Q3ListViewItem*)),
-		   this,SLOT(fwdExpanded(Q3ListViewItem*)));
-  QObject::connect(this,SIGNAL(collapsed(Q3ListViewItem*)),
-		   this,SLOT(fwdCollapsed(Q3ListViewItem*)));
-  QObject::connect(this,SIGNAL(returnPressed(Q3ListViewItem*)),
-		   this,SLOT(fwdReturnPressed(Q3ListViewItem*)));
-  QObject::connect(this,SIGNAL(doubleClicked(Q3ListViewItem*)),
-		   this,SLOT(fwdDoubleClicked(Q3ListViewItem*)));
+  QObject::connect(this, SIGNAL(itemSelectionChanged()),
+                   this, SLOT(fwdSelectionChanged()));
+  QObject::connect(this, SIGNAL(itemExpanded(QTreeWidgetItem*)),
+                   this, SLOT(fwdExpanded(QTreeWidgetItem*)));
+  QObject::connect(this, SIGNAL(itemCollapsed(QTreeWidgetItem*)),
+                   this, SLOT(fwdCollapsed(QTreeWidgetItem*)));
+  QObject::connect(this, SIGNAL(itemActivated(QTreeWidgetItem*,int)),
+                   this, SLOT(fwdReturnPressed(QTreeWidgetItem*,int)));
+  QObject::connect(this, SIGNAL(itemDoubleClicked(QTreeWidgetItem*,int)),
+                   this, SLOT(fwdDoubleClicked(QTreeWidgetItem*,int)));
 }
 //----------------------------------------------------------------------------
 
@@ -50,39 +45,39 @@ void FFuQtListView::fwdSelectionChanged()
 }
 //----------------------------------------------------------------------------
 
-void FFuQtListView::fwdExpanded(Q3ListViewItem* item)
+void FFuQtListView::fwdExpanded(QTreeWidgetItem* item)
 {
   this->onListItemOpened(dynamic_cast<FFuListViewItem*>(item),true);
 }
 //----------------------------------------------------------------------------
 
-void FFuQtListView::fwdCollapsed(Q3ListViewItem* item)
+void FFuQtListView::fwdCollapsed(QTreeWidgetItem* item)
 {
   this->onListItemOpened(dynamic_cast<FFuListViewItem*>(item),false);
 }
 //----------------------------------------------------------------------------
 
-void FFuQtListView::fwdReturnPressed(Q3ListViewItem* item)
+void FFuQtListView::fwdReturnPressed(QTreeWidgetItem* item, int)
 {
   this->invokeReturnPressedCB(dynamic_cast<FFuListViewItem*>(item));
 }
 //----------------------------------------------------------------------------
 
-void FFuQtListView::fwdDoubleClicked(Q3ListViewItem* item)
+void FFuQtListView::fwdDoubleClicked(QTreeWidgetItem* item, int)
 {
   this->invokeDoubleClickedCB(dynamic_cast<FFuListViewItem*>(item));
 }
 //----------------------------------------------------------------------------
 
-void FFuQtListView::setListSorting(int column,bool ascending)
+void FFuQtListView::setListSorting(int column, bool ascnd)
 {
-  this->setSorting(column,ascending);
+  this->sortByColumn(column, ascnd ? Qt::AscendingOrder : Qt::DescendingOrder);
 }
 //----------------------------------------------------------------------------
 
-void FFuQtListView::setHeaderClickEnabled(int column,bool enable)
+void FFuQtListView::setHeaderClickEnabled(int, bool enable)
 {
-  this->header()->setClickEnabled(enable,column);
+  this->header()->setClickable(enable);
 }
 //----------------------------------------------------------------------------
 
@@ -94,7 +89,7 @@ void FFuQtListView::setListRootIsDecorated(bool enable)
 
 void FFuQtListView::setSglSelectionMode(bool single)
 {
-  this->setSelectionMode(single ? Q3ListView::Single : Q3ListView::Extended);
+  this->setSelectionMode(single ? SingleSelection : ExtendedSelection);
 }
 //----------------------------------------------------------------------------
 
@@ -122,8 +117,11 @@ void FFuQtListView::clearList()
 
 void FFuQtListView::setListColumns(const std::vector<const char*>& labels)
 {
+  QStringList qLabels;
+  qLabels.reserve(labels.size());
   for (const char* label : labels)
-    this->addColumn(label);
+    qLabels.push_back(label);
+  this->setHeaderLabels(qLabels);
 }
 //----------------------------------------------------------------------------
 
@@ -133,16 +131,24 @@ void FFuQtListView::setListColumnWidth(int column, int width)
 }
 //----------------------------------------------------------------------------
 
-void FFuQtListView::permSelectListItem(FFuListViewItem* item, bool select, bool notify)
+void FFuQtListView::resizeListColumnsToContents()
 {
-  Q3ListViewItem* qitem = dynamic_cast<Q3ListViewItem*>(item);
+  for (int col = 0; col < this->columnCount(); col++)
+    this->resizeColumnToContents(col);
+}
+//----------------------------------------------------------------------------
+
+void FFuQtListView::permSelectListItem(FFuListViewItem* item,
+                                       bool select, bool notify)
+{
+  QTreeWidgetItem* qitem = dynamic_cast<QTreeWidgetItem*>(item);
   if (!qitem) return;
 
   bool wasblocked = this->areLibSignalsBlocked();
 
   if (!notify)
     this->blockLibSignals(true);
-  this->setSelected(qitem,select);
+  qitem->setSelected(select);
 
   this->blockLibSignals(wasblocked);
 }
@@ -160,37 +166,32 @@ void FFuQtListView::clearListSelection(bool notify)
 }
 //----------------------------------------------------------------------------
 
-void FFuQtListView::openListItem(FFuListViewItem* item,bool open,bool notify)
+void FFuQtListView::openListItem(FFuListViewItem* item,
+                                 bool open, bool notify)
 {
-  Q3ListViewItem* qitem = dynamic_cast<Q3ListViewItem*>(item);
+  QTreeWidgetItem* qitem = dynamic_cast<QTreeWidgetItem*>(item);
   if (!qitem) return;
 
   bool wasblocked = this->areLibSignalsBlocked();
 
   if (!notify)
     this->blockLibSignals(true);
-  qitem->setOpen(open);
+  qitem->setExpanded(open);
 
   this->blockLibSignals(wasblocked);
 }
 //----------------------------------------------------------------------------
 
-bool FFuQtListView::isExpanded(FFuListViewItem* item)
+void FFuQtListView::ensureListItemVisible(FFuListViewItem* item, bool notify)
 {
-  Q3ListViewItem* qitem = dynamic_cast<Q3ListViewItem*>(item);
-  return qitem ? this->isOpen(qitem) : false;
-}
-
-void FFuQtListView::ensureListItemVisible(FFuListViewItem* item,bool notify)
-{
-  Q3ListViewItem* qitem = dynamic_cast<Q3ListViewItem*>(item);
+  QTreeWidgetItem* qitem = dynamic_cast<QTreeWidgetItem*>(item);
   if (!qitem) return;
 
   bool wasblocked = this->areLibSignalsBlocked();
 
   if (!notify)
     this->blockLibSignals(true);
-  this->ensureItemVisible(qitem);
+  this->scrollTo(this->indexFromItem(qitem));
 
   this->blockLibSignals(wasblocked);
 }
@@ -198,7 +199,10 @@ void FFuQtListView::ensureListItemVisible(FFuListViewItem* item,bool notify)
 
 FFuListViewItem* FFuQtListView::getSelectedListItemSglMode()
 {
-  return dynamic_cast<FFuListViewItem*>(this->selectedItem());
+  QList<QTreeWidgetItem*> selected = this->selectedItems();
+  if (selected.isEmpty()) return NULL;
+
+  return dynamic_cast<FFuListViewItem*>(selected.front());
 }
 //----------------------------------------------------------------------------
 
@@ -210,20 +214,13 @@ FFuListViewItem* FFuQtListView::getCurrentListItem()
 
 FFuListViewItem* FFuQtListView::getFirstChildItem()
 {
-  return dynamic_cast<FFuListViewItem*>(this->firstChild());
+  return dynamic_cast<FFuListViewItem*>(this->topLevelItem(0));
 }
 //----------------------------------------------------------------------------
-
 
 bool FFuQtListView::isSglSelectionMode() const
 {
-  return this->selectionMode() == Q3ListView::Single;
-}
-//----------------------------------------------------------------------------
-
-int FFuQtListView::getNColumns()
-{
-  return this->columns();
+  return this->selectionMode() == SingleSelection;
 }
 //----------------------------------------------------------------------------
 
@@ -303,7 +300,7 @@ void FFuQtListView::setColors(FFuaPalette aPalette)
 
   QPalette textFieldPalette(textFieldNormal, textFieldDisabled, textFieldNormal);
 
-  this->Q3ListView::setPalette(textFieldPalette);
+  this->setPalette(textFieldPalette);
 
   QColorGroup stdNormal   (TextOnStdBackground,
 			   StdBackground,
@@ -335,7 +332,7 @@ void FFuQtListView::setFonts (FFuaFontSet aFontSet)
   listviewFont.setBold     (aFontSet.TextFieldFont.IsBold  );
   listviewFont.setItalic   (aFontSet.TextFieldFont.IsItalic);
 
-  this->Q3ListView::setFont(listviewFont);
+  this->setFont(listviewFont);
 
   QFont stdFont;
   stdFont.setFamily   (aFontSet.StandardFont.Family.c_str());
@@ -347,43 +344,39 @@ void FFuQtListView::setFonts (FFuaFontSet aFontSet)
 }
 //----------------------------------------------------------------------------
 
-void FFuQtListView::viewportMousePressEvent(QMouseEvent* e)
+void FFuQtListView::mousePressEvent(QMouseEvent* e)
 {
-  // every press not only on items
-  FFuListViewItem* listItem = dynamic_cast<FFuListViewItem*>(this->itemAt(e->pos()));
-  if (listItem && e->button() == Qt::LeftButton)
+  FFuListViewItem* item = dynamic_cast<FFuListViewItem*>(this->itemAt(e->pos()));
+  if (e->button() & Qt::LeftButton)
+  {
+    if (item && item->isItemToggleAble()) // Manual toggling
     {
-      // manual toggling
-      if (listItem->isItemToggleAble()) {
-	int offset = this->rootIsDecorated() ? this->treeStepSize() : 0;
-	FFuListViewItem* parent = listItem;
-	while ((parent = parent->getParentItem()))
-	  offset += this->treeStepSize();
-	if (offset < e->pos().x() && e->pos().x() < offset+15) {
-	  listItem->toggleItem(true);
-	  return;
-	}
+      int levels = item->getDepth() + (this->rootIsDecorated() ? 1 : 0);
+      int offset = e->pos().x() - this->indentation()*levels;
+      if (offset > 0 && offset < 15)
+      {
+        item->toggleItem(true);
+        return;
       }
+    }
 
-      // Changed 28.10.16 (kmo): Invoke call-back method before
-      // the Q3ListView::viewportMousePressEvent call
-      this->invokeLeftMouseBPressedCB(listItem);
-      this->Q3ListView::viewportMousePressEvent(e);
-    }
-  else if (e->button() == Qt::RightButton)
-    {
-      this->invokeRightMouseBPressedCB(listItem);
-      this->executePopUp(listItem);
-    }
+    this->invokeLeftMouseBPressedCB(item);
+  }
+  else if (e->button() & Qt::RightButton)
+  {
+    this->invokeRightMouseBPressedCB(item);
+    this->executePopUp(item);
+  }
+
+  this->QTreeWidget::mousePressEvent(e);
 }
 //----------------------------------------------------------------------------
 
-void FFuQtListView::viewportMouseReleaseEvent(QMouseEvent* e)
+void FFuQtListView::mouseReleaseEvent(QMouseEvent* e)
 {
-  // every release not only on items
-  if (e->button() == Qt::LeftButton)
+  if (e->button() & Qt::LeftButton)
     this->invokeLeftMouseBReleaseCB();
 
-  this->Q3ListView::viewportMouseReleaseEvent(e);
+  this->QTreeWidget::mouseReleaseEvent(e);
 }
 //----------------------------------------------------------------------------

--- a/src/FFuLib/FFuQtComponents/FFuQtListView.C
+++ b/src/FFuLib/FFuQtComponents/FFuQtListView.C
@@ -197,7 +197,7 @@ void FFuQtListView::ensureListItemVisible(FFuListViewItem* item, bool notify)
 }
 //----------------------------------------------------------------------------
 
-FFuListViewItem* FFuQtListView::getSelectedListItemSglMode()
+FFuListViewItem* FFuQtListView::getSelectedListItemSglMode() const
 {
   QList<QTreeWidgetItem*> selected = this->selectedItems();
   if (selected.isEmpty()) return NULL;
@@ -206,13 +206,13 @@ FFuListViewItem* FFuQtListView::getSelectedListItemSglMode()
 }
 //----------------------------------------------------------------------------
 
-FFuListViewItem* FFuQtListView::getCurrentListItem()
+FFuListViewItem* FFuQtListView::getCurrentListItem() const
 {
   return dynamic_cast<FFuListViewItem*>(this->currentItem());
 }
 //----------------------------------------------------------------------------
 
-FFuListViewItem* FFuQtListView::getFirstChildItem()
+FFuListViewItem* FFuQtListView::getFirstChildItem() const
 {
   return dynamic_cast<FFuListViewItem*>(this->topLevelItem(0));
 }
@@ -221,6 +221,14 @@ FFuListViewItem* FFuQtListView::getFirstChildItem()
 bool FFuQtListView::isSglSelectionMode() const
 {
   return this->selectionMode() == SingleSelection;
+}
+//----------------------------------------------------------------------------
+
+const char* FFuQtListView::getName() const
+{
+  static std::string name;
+  name = this->objectName().toStdString();
+  return name.c_str();
 }
 //----------------------------------------------------------------------------
 

--- a/src/FFuLib/FFuQtComponents/FFuQtListView.C
+++ b/src/FFuLib/FFuQtComponents/FFuQtListView.C
@@ -232,32 +232,19 @@ const char* FFuQtListView::getName() const
 }
 //----------------------------------------------------------------------------
 
-FFuListViewItem* FFuQtListView::createListItem(FFuListViewItem* parent,FFuListViewItem* after,
-					       FFuListViewItem* original,const char* label)
+FFuListViewItem* FFuQtListView::createListItem(const char* label,
+                                               FFuListViewItem* parent,
+                                               FFuListViewItem* after)
 {
-  FFuQtListViewItem* lvi = NULL;
-
+  FFuQtListViewItem* lvi;
   if (!parent)
-    if (original)
-      lvi = new FFuQtListViewItem(this,(FFuQtListViewItem*)(after),
-				  (FFuQtListViewItem*)(original));
-    else
-      lvi = new FFuQtListViewItem(this,(FFuQtListViewItem*)(after),
-				  label);
+    lvi = new FFuQtListViewItem(this,
+                                static_cast<FFuQtListViewItem*>(after), label);
   else
-    if (original)
-      lvi = new FFuQtListViewItem((FFuQtListViewItem*)(parent),
-				  (FFuQtListViewItem*)(after),
-				  (FFuQtListViewItem*)(original));
-    else
-      lvi = new FFuQtListViewItem((FFuQtListViewItem*)(parent),
-				  (FFuQtListViewItem*)(after),label);
+    lvi = new FFuQtListViewItem(static_cast<FFuQtListViewItem*>(parent),
+                                static_cast<FFuQtListViewItem*>(after), label);
 
-  if (lvi){
-    this->lviMap[lvi->getItemId()] = lvi;
-    //lvi->setItemDragable(true);
-    //lvi->setItemDropable(true);
-  }
+  this->lviMap[lvi->getItemId()] = lvi;
   return lvi;
 }
 //----------------------------------------------------------------------------

--- a/src/FFuLib/FFuQtComponents/FFuQtListView.H
+++ b/src/FFuLib/FFuQtComponents/FFuQtListView.H
@@ -39,6 +39,7 @@ protected slots:
   void fwdCollapsed(QTreeWidgetItem* item);
   void fwdReturnPressed(QTreeWidgetItem* item, int);
   void fwdDoubleClicked(QTreeWidgetItem* item, int);
+  void fwdHeaderClicked(int);
 
 public:
   virtual void setListSorting(int column, bool ascending);

--- a/src/FFuLib/FFuQtComponents/FFuQtListView.H
+++ b/src/FFuLib/FFuQtComponents/FFuQtListView.H
@@ -5,16 +5,10 @@
 // This file is part of FEDEM - https://openfedem.org
 ////////////////////////////////////////////////////////////////////////////////
 
-/*!
-   Signals: Do not trust the MouseButton press/release signal because they are
-   not given at the right time. Instead use the viewportMousePressEvent and
-   viewportMouseReleaseEvent signals.
-*/
-
 #ifndef FFU_QT_LIST_VIEW_H
 #define FFU_QT_LIST_VIEW_H
 
-#include <Qt3Support/Q3ListView>
+#include <QTreeWidget>
 
 #include "FFuLib/FFuQtBaseClasses/FFuQtComponentBase.H"
 #include "FFuLib/FFuListView.H"
@@ -22,27 +16,33 @@
 class QMouseEvent;
 
 
-class FFuQtListView : public Q3ListView, virtual public FFuListView,
-		      public FFuQtComponentBase
+/*!
+  \brief Qt-implementation of Fedem listview widgets based on QTreeWidget.
+  \details Do not trust the MouseButton press/release signal because they
+  are not given at the right time. Instead use the mousePressEvent() and
+  mouseReleaseEvent() signals.
+*/
+
+class FFuQtListView : public QTreeWidget, virtual public FFuListView,
+                      public FFuQtComponentBase
 {
   Q_OBJECT
 
 public:
-  // Columns get maximum widthmode.
-  FFuQtListView(QWidget* parent = 0, int nColumns = 0,
-		const char* name = "FFuQtListView");
+  FFuQtListView(QWidget* parent = NULL, int nColumns = 0,
+                const char* name = "FFuQtListView");
   virtual ~FFuQtListView() {}
 
 protected slots:
   void fwdSelectionChanged();
-  void fwdExpanded(Q3ListViewItem* item);
-  void fwdCollapsed(Q3ListViewItem* item);
-  void fwdReturnPressed(Q3ListViewItem* item);
-  void fwdDoubleClicked(Q3ListViewItem* item);
+  void fwdExpanded(QTreeWidgetItem* item);
+  void fwdCollapsed(QTreeWidgetItem* item);
+  void fwdReturnPressed(QTreeWidgetItem* item, int);
+  void fwdDoubleClicked(QTreeWidgetItem* item, int);
 
 public:
-  virtual void setListSorting(int column,bool ascending = true);
-  virtual void setHeaderClickEnabled(int column,bool enable);
+  virtual void setListSorting(int column, bool ascending);
+  virtual void setHeaderClickEnabled(int column, bool enable);
   virtual void setListRootIsDecorated(bool enable);
   virtual void setAllListColumnsShowSelection(bool enable);
   virtual void setHeaderOff(bool Off);
@@ -51,13 +51,12 @@ public:
 
   virtual void setListColumns(const std::vector<const char*>& labels);
   virtual void setListColumnWidth(int column, int width);
-  virtual void permSelectListItem(FFuListViewItem* item,
-				  bool select=true,bool notify=false);
-  virtual void clearListSelection(bool notify=false);
-  virtual void openListItem(FFuListViewItem* item,bool open,bool notify=false);
-  virtual void ensureListItemVisible(FFuListViewItem* item,bool notify=false);
-
-  virtual bool isExpanded(FFuListViewItem* item);
+  virtual void resizeListColumnsToContents();
+  virtual void permSelectListItem(FFuListViewItem* item, bool select,
+                                  bool notify);
+  virtual void clearListSelection(bool notify);
+  virtual void openListItem(FFuListViewItem* item, bool open, bool notify);
+  virtual void ensureListItemVisible(FFuListViewItem* item, bool notify);
 
   virtual void setSglSelectionMode(bool single);
   virtual bool isSglSelectionMode() const;
@@ -65,7 +64,6 @@ public:
   virtual FFuListViewItem* getSelectedListItemSglMode();
   virtual FFuListViewItem* getCurrentListItem();
   virtual FFuListViewItem* getFirstChildItem();
-  virtual int getNColumns();
 
   virtual FFuListViewItem* createListItem(FFuListViewItem* parent=0,
 					  FFuListViewItem* after=0,
@@ -77,9 +75,9 @@ private:
   virtual void setFonts (FFuaFontSet aFontSet);
   virtual void setColors(FFuaPalette aPalette);
 
-  // QListView  Re-impl
-  virtual void viewportMousePressEvent(QMouseEvent* e);
-  virtual void viewportMouseReleaseEvent(QMouseEvent* e);
+  // QTreeWidget re-implementations
+  virtual void mousePressEvent(QMouseEvent* e);
+  virtual void mouseReleaseEvent(QMouseEvent* e);
 };
 
 #endif

--- a/src/FFuLib/FFuQtComponents/FFuQtListView.H
+++ b/src/FFuLib/FFuQtComponents/FFuQtListView.H
@@ -67,10 +67,9 @@ public:
   virtual FFuListViewItem* getCurrentListItem() const;
   virtual FFuListViewItem* getFirstChildItem() const;
 
-  virtual FFuListViewItem* createListItem(FFuListViewItem* parent=0,
-					  FFuListViewItem* after=0,
-					  FFuListViewItem* original=0,
-					  const char* label="item");
+  virtual FFuListViewItem* createListItem(const char* label,
+                                          FFuListViewItem* parent,
+                                          FFuListViewItem* after);
 
 private:
   // FFuComponentBase Re-impl

--- a/src/FFuLib/FFuQtComponents/FFuQtListView.H
+++ b/src/FFuLib/FFuQtComponents/FFuQtListView.H
@@ -61,9 +61,11 @@ public:
   virtual void setSglSelectionMode(bool single);
   virtual bool isSglSelectionMode() const;
 
-  virtual FFuListViewItem* getSelectedListItemSglMode();
-  virtual FFuListViewItem* getCurrentListItem();
-  virtual FFuListViewItem* getFirstChildItem();
+  virtual const char* getName() const;
+
+  virtual FFuListViewItem* getSelectedListItemSglMode() const;
+  virtual FFuListViewItem* getCurrentListItem() const;
+  virtual FFuListViewItem* getFirstChildItem() const;
 
   virtual FFuListViewItem* createListItem(FFuListViewItem* parent=0,
 					  FFuListViewItem* after=0,

--- a/src/FFuLib/FFuQtComponents/FFuQtListViewItem.C
+++ b/src/FFuLib/FFuQtComponents/FFuQtListViewItem.C
@@ -17,65 +17,30 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-FFuQtListViewItem::FFuQtListViewItem(FFuQtListView* parent,FFuQtListViewItem* after,const char* label)
+FFuQtListViewItem::FFuQtListViewItem(FFuQtListView* parent,
+                                     FFuQtListViewItem* after,
+                                     const char* label)
   : QTreeWidgetItem(parent,after)
 {
-  this->setItemText(0,label);
+  if (label)
+    this->setText(0,label);
 }
 //----------------------------------------------------------------------------
 
-FFuQtListViewItem::FFuQtListViewItem(FFuQtListView* parent,FFuQtListViewItem* after,
-				     FFuQtListViewItem* original)
+FFuQtListViewItem::FFuQtListViewItem(FFuQtListViewItem* parent,
+                                     FFuQtListViewItem* after,
+                                     const char* label)
   : QTreeWidgetItem(parent,after)
 {
-  this->copyData(original);
-}
-//----------------------------------------------------------------------------
-
-FFuQtListViewItem::FFuQtListViewItem(FFuQtListViewItem* parent,FFuQtListViewItem* after,const char* label)
-  : QTreeWidgetItem(parent,after)
-{
-  this->setItemText(0,label);
-}
-//----------------------------------------------------------------------------
-
-FFuQtListViewItem::FFuQtListViewItem(FFuQtListViewItem* parent,FFuQtListViewItem* after,
-				     FFuQtListViewItem* original)
-  : QTreeWidgetItem(parent,after)
-{
-  this->copyData(original);
-}
-//----------------------------------------------------------------------------
-
-void FFuQtListViewItem::copyPixmaps(FFuListViewItem* original)
-{
-  QTreeWidgetItem* item = dynamic_cast<QTreeWidgetItem*>(original);
-  if (!item) return;
-
-  for (int col = 0; col < this->columnCount(); col++)
-  {
-    QIcon ic = item->icon(col);
-    if (!ic.isNull()) this->setIcon(col,ic);
-  }
-}
-//----------------------------------------------------------------------------
-
-void FFuQtListViewItem::copyTexts(FFuListViewItem* original)
-{
-  QTreeWidgetItem* item = dynamic_cast<QTreeWidgetItem*>(original);
-  if (!item) return;
-
-  for (int col = 0; col < item->columnCount(); col++)
-  {
-    this->setText(col,item->text(col));
-    this->setFont(col,item->font(col));
-  }
+  if (label)
+    this->setText(0,label);
 }
 //----------------------------------------------------------------------------
 
 void FFuQtListViewItem::setItemText(int col, const char* text)
 {
-  this->setText(col,text);
+  if (text)
+    this->setText(col,text);
 }
 //----------------------------------------------------------------------------
 

--- a/src/FFuLib/FFuQtComponents/FFuQtListViewItem.H
+++ b/src/FFuLib/FFuQtComponents/FFuQtListViewItem.H
@@ -26,25 +26,24 @@ public:
   virtual ~FFuQtListViewItem() {}
   virtual void copyPixmaps(FFuListViewItem* original);
 
-  virtual void  setItemText(int col,const char* text);
-  virtual char* getItemText(int col=0);
-  virtual void setItemTextBold(bool bold=true);
-  virtual void setItemTextItalic(bool italic=true);
-  virtual void setItemImage(int col,const char **pixmap);
-  virtual bool isItemSelected();
-  virtual int  getDepth();
+  virtual void        setItemText(int col, const char* text);
+  virtual std::string getItemText(int col) const;
+  virtual void setItemTextBold(int col, bool bold);
+  virtual void setItemTextItalic(int col, bool italic);
+  virtual void setItemImage(int col, const char** pixmap);
   virtual void setItemSelectable(bool enable);
+  virtual bool isItemSelected() const;
 
-  virtual FFuListView*     getListView();
-  virtual FFuListViewItem* getParentItem();
-  virtual FFuListViewItem* getFirstChildItem();
-  virtual FFuListViewItem* getLastChildItem();
-  virtual FFuListViewItem* getNextSiblingItem();
-  virtual int              getNSiblings();
-  virtual int              getNChildren();
+  virtual FFuListView*     getListView() const;
+  virtual FFuListViewItem* getParentItem() const;
+  virtual FFuListViewItem* getFirstChildItem() const;
+  virtual FFuListViewItem* getLastChildItem() const;
+  virtual FFuListViewItem* getNextSiblingItem() const;
+  virtual int              getNSiblings() const;
+  virtual int              getNChildren() const;
 
-  virtual void setItemToggleAble(bool able);
-  virtual void setToggleValue(int toggle,bool notify=false);
+  virtual void setItemToggleAble(unsigned char able);
+  virtual void setToggleValue(int toggle, bool notify);
 
   virtual void setItemDropable(bool enable);
   virtual void setItemDragable(bool enable);

--- a/src/FFuLib/FFuQtComponents/FFuQtListViewItem.H
+++ b/src/FFuLib/FFuQtComponents/FFuQtListViewItem.H
@@ -17,16 +17,13 @@ class FFuQtListView;
 class FFuQtListViewItem : public QTreeWidgetItem, public FFuListViewItem
 {
 public:
-  // If parent=0, the item is created at top level in the list view
-  // If after=0 the item is inserted first in parents list
-  FFuQtListViewItem(FFuQtListView* parent,FFuQtListViewItem* after,const char* label);
-  FFuQtListViewItem(FFuQtListView* parent,FFuQtListViewItem* after,FFuQtListViewItem* original);
-  FFuQtListViewItem(FFuQtListViewItem* parent,FFuQtListViewItem* after,const char* label);
-  FFuQtListViewItem(FFuQtListViewItem* parent,FFuQtListViewItem* after,FFuQtListViewItem* original);
+  FFuQtListViewItem(FFuQtListView* parent,
+                    FFuQtListViewItem* after,
+                    const char* label);
+  FFuQtListViewItem(FFuQtListViewItem* parent,
+                    FFuQtListViewItem* after,
+                    const char* label);
   virtual ~FFuQtListViewItem() {}
-
-  virtual void copyPixmaps(FFuListViewItem* original);
-  virtual void copyTexts(FFuListViewItem* original);
 
   virtual void        setItemText(int col, const char* text);
   virtual std::string getItemText(int col) const;

--- a/src/FFuLib/FFuQtComponents/FFuQtListViewItem.H
+++ b/src/FFuLib/FFuQtComponents/FFuQtListViewItem.H
@@ -9,12 +9,12 @@
 #define FFU_QT_LIST_VIEW_ITEM_H
 
 #include "FFuLib/FFuListViewItem.H"
-#include <Qt3Support/Q3ListView>
-
+#include <QTreeWidgetItem>
 
 class FFuQtListView;
 
-class FFuQtListViewItem : public Q3ListViewItem, public FFuListViewItem
+
+class FFuQtListViewItem : public QTreeWidgetItem, public FFuListViewItem
 {
 public:
   // If parent=0, the item is created at top level in the list view
@@ -24,7 +24,9 @@ public:
   FFuQtListViewItem(FFuQtListViewItem* parent,FFuQtListViewItem* after,const char* label);
   FFuQtListViewItem(FFuQtListViewItem* parent,FFuQtListViewItem* after,FFuQtListViewItem* original);
   virtual ~FFuQtListViewItem() {}
+
   virtual void copyPixmaps(FFuListViewItem* original);
+  virtual void copyTexts(FFuListViewItem* original);
 
   virtual void        setItemText(int col, const char* text);
   virtual std::string getItemText(int col) const;
@@ -32,7 +34,8 @@ public:
   virtual void setItemTextItalic(int col, bool italic);
   virtual void setItemImage(int col, const char** pixmap);
   virtual void setItemSelectable(bool enable);
-  virtual bool isItemSelected() const;
+  virtual bool isItemSelected() const { return this->isSelected(); }
+  virtual bool isItemExpanded() const { return this->isExpanded(); }
 
   virtual FFuListView*     getListView() const;
   virtual FFuListViewItem* getParentItem() const;
@@ -40,7 +43,8 @@ public:
   virtual FFuListViewItem* getLastChildItem() const;
   virtual FFuListViewItem* getNextSiblingItem() const;
   virtual int              getNSiblings() const;
-  virtual int              getNChildren() const;
+  virtual int              getNChildren() const { return this->childCount(); }
+  virtual int              getNColumns() const { return this->columnCount(); }
 
   virtual void setItemToggleAble(unsigned char able);
   virtual void setToggleValue(int toggle, bool notify);
@@ -49,10 +53,7 @@ public:
   virtual void setItemDragable(bool enable);
 
 private:
-  //reimpl from QListItem
-  virtual void setSelected(bool selected);
-  virtual void paintCell(QPainter* p,const QColorGroup& cg,int column,int width,int align);
-  virtual void paintFocus(QPainter* p,const QColorGroup& cg,const QRect& r);
+  void toggleFlag(bool enable, Qt::ItemFlags flag);
 };
 
 #endif

--- a/src/vpmApp/vpmAppCmds/FapEditCmds.C
+++ b/src/vpmApp/vpmAppCmds/FapEditCmds.C
@@ -498,9 +498,8 @@ void FapEditCmds::selectTempSelectionAll()
   FFuListViewItem* firstItem = listView->getFirstChildItem();
   if (!firstItem) return;
 
-  char* pszIds = firstItem->getItemText(1);
-  bool firstItemHasIds = pszIds != NULL ? (strlen(pszIds) > 0) : false;
-  std::vector<FFuListViewItem*> items = listView->getListChildren(firstItemHasIds ? NULL : firstItem);
+  if (!firstItem->getItemText(1).empty()) firstItem = NULL;
+  std::vector<FFuListViewItem*> items = listView->getListChildren(firstItem);
 
   // All possible object type prefices in the Topology view.
   // See also FapUAProperties::getDBValues().
@@ -516,13 +515,12 @@ void FapEditCmds::selectTempSelectionAll()
   std::vector<FFaViewItem*> itemsToSel;
   for (FFuListViewItem* item : items)
   {
-    char* pszType = item->getItemText(0);
-    char* pszIds = item->getItemText(1);
-    if (pszType == NULL || pszIds == NULL)
-      continue;
+    std::string strType = item->getItemText(0);
+    if (strType.empty()) continue;
+    std::string strUIds = item->getItemText(1);
+    if (strUIds.empty()) continue;
 
     // Remove possible object type prefix
-    std::string strType = pszType;
     for (const char* pfx : pfxs)
       if (strType.find(pfx) == 0)
       {
@@ -531,6 +529,7 @@ void FapEditCmds::selectTempSelectionAll()
       }
 
     // Get id of item
+    const char* pszIds = strUIds.c_str();
     // The first number is the id of the element
     int id = atol(pszIds);
     // The other numbers are the ids of the parent assemblies

--- a/src/vpmApp/vpmAppUAMap/FapUACSListView.C
+++ b/src/vpmApp/vpmAppUAMap/FapUACSListView.C
@@ -126,7 +126,8 @@ bool FapUACSListView::importCS(FFaViewItem* csItem, FFaViewItem* matItem)
     bp->ShrCentre.setValue(std::make_pair((*bcs)[8],(*bcs)[9]));
 
   bp->crossSectionType.setValue(FmBeamProperty::GENERIC);
-  bp->setUserDescription(bcs->getItemName() + std::string(", ") + mat->getItemName());
+  bp->setUserDescription(bcs->getItemName() + std::string(", ") +
+                         mat->getItemName());
   bp->onChanged();
 
   ListUI <<"  -> Imported "<< bp->getIdString(true) <<"\n";
@@ -140,17 +141,18 @@ bool FapUACSListView::singleSelectionMode() const
 }
 //----------------------------------------------------------------------------
 
-std::vector<std::string> FapUACSListView::getItemText(FFaListViewItem* item)
+std::string FapUACSListView::getItemText(FFaListViewItem* item)
 {
-  return { item->getItemDescr() };
+  return item->getItemDescr();
 }
 //----------------------------------------------------------------------------
 
 void FapUACSListView::getChildren(FFaListViewItem* parent,
-				   std::vector<FFaListViewItem*>& children) const
+                                  std::vector<FFaListViewItem*>& children) const
 {
   children.clear();
-  PropertyMap::const_iterator pit = myDataBase.find(parent ? parent->getItemName() : "root");
+  const char* parentName = parent ? parent->getItemName() : "root";
+  PropertyMap::const_iterator pit = myDataBase.find(parentName);
   if (pit == myDataBase.end()) return;
 
   children.reserve(pit->second.size());
@@ -159,7 +161,8 @@ void FapUACSListView::getChildren(FFaListViewItem* parent,
 }
 //----------------------------------------------------------------------------
 
-FapUACSListView::PropertyItem::PropertyItem(const std::string& name, int id, size_t n)
+FapUACSListView::PropertyItem::PropertyItem(const std::string& name,
+                                            int id, size_t n)
 {
   myName = name;
   myID = id;

--- a/src/vpmApp/vpmAppUAMap/FapUACSListView.H
+++ b/src/vpmApp/vpmAppUAMap/FapUACSListView.H
@@ -80,7 +80,7 @@ protected:
   virtual void getChildren(FFaListViewItem* parent,
                            std::vector<FFaListViewItem*>& children) const;
 
-  virtual std::vector<std::string> getItemText(FFaListViewItem* item);
+  virtual std::string getItemText(FFaListViewItem* item);
 
 private:
   typedef std::vector<PropertyItem>         PropertyVec;

--- a/src/vpmApp/vpmAppUAMap/FapUAItemsListView.C
+++ b/src/vpmApp/vpmAppUAMap/FapUAItemsListView.C
@@ -61,7 +61,7 @@ void FapUAItemsListView::setTopLevelItem(FFaListViewItem* item, bool includeMe)
 }
 //----------------------------------------------------------------------------
 
-FFaListViewItem* FapUAItemsListView::getUIParent(FFaListViewItem* item)
+FFaListViewItem* FapUAItemsListView::getUIParent(FFaListViewItem* item) const
 {
 #ifdef LV_DEBUG
   reportItem(item,"FapUAItemsListView::getUIParent: ");
@@ -127,7 +127,8 @@ void FapUAItemsListView::sortByID()
 
 void FapUAItemsListView::ensureSelectedVisible()
 {
-  for (FFuListViewItem* item : ui->getSelectedListItems())
+  std::vector<FFuListViewItem*> selected = ui->getSelectedListItems();
+  for (FFuListViewItem* item : selected)
     ui->ensureListItemVisible(item,false);
 }
 //----------------------------------------------------------------------------
@@ -141,7 +142,7 @@ void FapUAItemsListView::deleteUIItem(FFaViewItem* item)
   int uiitem = this->getMapItem(item);
   if (uiitem < 0) return;
 
-  std::vector<int> children = this->ui->getAllChildren(uiitem);
+  std::vector<int> children = this->ui->getChildren(uiitem,true);
 
   this->ui->deleteItem(uiitem);
   this->eraseMapItem(uiitem);
@@ -159,8 +160,10 @@ void FapUAItemsListView::ensureItemVisible(FFaViewItem* item)
 
 void FapUAItemsListView::updateItemPositionsInDB(int uiparent)
 {
+  std::vector<int> children = this->ui->getChildren(uiparent);
+
   int pos = 0;
-  for (int child : this->ui->getChildren(uiparent))
+  for (int child : children)
     this->getMapLVItem(child)->setPositionInListView(this->ui->getName(),pos++);
 }
 //----------------------------------------------------------------------------
@@ -192,9 +195,9 @@ bool FapUAItemsListView::getItemExpanded(FFaListViewItem* item)
 }
 //----------------------------------------------------------------------------
 
-std::vector<std::string> FapUAItemsListView::getItemText(FFaListViewItem* item)
+std::string FapUAItemsListView::getItemText(FFaListViewItem* item)
 {
-  return { item->getItemName()+FFaNumStr(" %d",item->getItemID()) };
+  return item->getItemName() + FFaNumStr(" %d",item->getItemID());
 }
 //----------------------------------------------------------------------------
 
@@ -241,7 +244,7 @@ void FapUAItemsListView::updateTopLevelItem()
   if (this->topLevelItem) {
     if (this->topLevelItemIncludeMyself) {
       if (this->verifyItem(this->topLevelItem))
-	this->createUIItem(this->topLevelItem);
+        this->createUIItem(this->topLevelItem,NULL,NULL);
     }
     else
       this->createUITopLevelItems(this->topLevelItem);
@@ -308,15 +311,11 @@ int FapUAItemsListView::createSingleUIItem(FFaListViewItem* item,
 
   if (this->getMapItem(item) > -1) return -1;
 
-  int uiitem = -1;
-  std::vector<std::string> texts = this->getItemText(item);
-  if (texts.size() == 1)
-    uiitem = this->ui->createItem(this->getMapItem(parent),
-				  this->getMapItem(after),texts.front().c_str());
-  else if (texts.size() > 1) {
-    uiitem = this->ui->createItem(this->getMapItem(parent),this->getMapItem(after));
-    this->ui->setItemText(uiitem,texts);
-  }
+  int uiitem = this->ui->createItem(this->getMapItem(parent),
+                                    this->getMapItem(after),
+                                    this->getItemText(item));
+  if (uiitem < 0) return uiitem;
+
   this->putMapItem(uiitem,item);
 
   //settings
@@ -345,7 +344,8 @@ int FapUAItemsListView::createSingleUIItem(FFaListViewItem* item,
   }
 
 #ifdef LV_DEBUG
-  std::cout <<"FapUAItemsListView::createSingleUIItem: Created item "<< uiitem << std::endl;
+  std::cout <<"FapUAItemsListView::createSingleUIItem: Created item "
+            << uiitem <<" for "<< this->getItemText(item) << std::endl;
 #endif
 
   return uiitem;
@@ -522,7 +522,8 @@ void FapUAItemsListView::onListViewItemChanged(FFaListViewItem* item)
   this->createUIItem(item, parent, after);
 
   // Handle selection, since this will now be removed
-  for (FFaViewItem* permSel : FapEventManager::getPermSelection())
+  std::vector<FFaViewItem*> selection = FapEventManager::getPermSelection();
+  for (FFaViewItem* permSel : selection)
     this->ui->permSelectItem(this->getMapItem(permSel));
 }
 //----------------------------------------------------------------------------

--- a/src/vpmApp/vpmAppUAMap/FapUAItemsListView.H
+++ b/src/vpmApp/vpmAppUAMap/FapUAItemsListView.H
@@ -19,14 +19,14 @@ class FFaListViewItem;
 /*!
   The class has an automatic connection with DB which enables it to maintain
   the view under changes in DB as connect/disconnect and description change.
-  Before this, the system should be initiated by calling updateUIValues.
+  Before this, the system should be initiated by calling updateUIValues().
 
   Listview positioning principle: If one item is subject to positioning,
   then all siblings are too.
 
   If you want to control item positions in the listview, you must set the
   items positionInListView variable (> -1) before the item gets in touch
-  with this class (e.g., in getChildren, etc.)
+  with this class (e.g., in getChildren(), etc.)
 
   \author Dag R Christensen
 */
@@ -53,7 +53,7 @@ public:
 
   void ensureItemVisible(FFaViewItem* item);
 
-  FFaListViewItem* getUIParent(FFaListViewItem* item);
+  FFaListViewItem* getUIParent(FFaListViewItem* item) const;
 
   void sortByID();
   void sortByName();
@@ -63,8 +63,8 @@ protected:
   // Functionality
   void createUITopLevelItems(FFaListViewItem* parent);
   void createUIItem(FFaListViewItem* item,
-		    FFaListViewItem* parent = 0,
-		    FFaListViewItem* after = 0);
+		    FFaListViewItem* parent,
+		    FFaListViewItem* after);
   virtual void deleteUIItem(FFaViewItem* item);
 
   virtual void dropItems(int, bool, void*) {}
@@ -73,22 +73,21 @@ protected:
 
   void updateItemPositionsInDB(int uiparent);
 
-  static void reportItem(FFaViewItem* item, const char* prefix = 0);
+  static void reportItem(FFaViewItem* item, const char* prefix = NULL);
 
 private:
   // For callback purpose only
   void tmpSelectItem(int item);
   void expandItem(int item, bool open);
 
+protected:
   // from FapUAItemsViewHandler
   // You should always start your view session by updateUIValues
   // since it initialises the session
-protected:
   virtual void updateSession();
   void updateTopLevelItem();
 
   // from FapUAExistenceHandler
-private:
   // These methods should be re-impl if you want this class to work as expected
 
   // listview settings
@@ -97,7 +96,6 @@ private:
   virtual bool getShowHeader() { return false; }
   virtual bool getHeaderClickEnabling() { return false; }
 
-protected:
   // listview hierarchy
   virtual bool isHeaderOkAsLeaf(FFaListViewItem*) const { return false; }
 
@@ -110,7 +108,7 @@ protected:
   // Those who are asking for their parents have been verified. Its only purpose
   // is to tell supposed parents for onListViewItemConnected items, etc.
   virtual FFaListViewItem* getParent(FFaListViewItem*,
-				     const std::vector<int>&) const { return 0; }
+				     const std::vector<int>&) const { return NULL; }
 
   // The objects you let thru here will also be verified,
   // so you can give any FFaListViewItem object,
@@ -118,12 +116,11 @@ protected:
   virtual void getChildren(FFaListViewItem* parent,
 			   std::vector<FFaListViewItem*>& children) const = 0;
 
-private:
   // listview item settings
   virtual bool getItemSelectAble(FFaViewItem*) { return true; }
   virtual bool getItemExpanded(FFaListViewItem* item);
 
-  virtual std::vector<std::string> getItemText(FFaListViewItem* item);
+  virtual std::string getItemText(FFaListViewItem* item);
   virtual bool getItemTextBold(FFaListViewItem*) { return false; }
   virtual bool getItemTextItalic(FFaListViewItem*) { return false; }
   virtual const char** getItemPixmap(FFaListViewItem* item);
@@ -132,6 +129,7 @@ private:
   virtual bool getItemThreeStepToggleAble(FFaListViewItem*) { return false; }
   virtual int getItemToggleValue(FFaListViewItem*) { return 0; }
 
+private:
   void getVerifiedChildren(FFaListViewItem* parent,
 			   std::vector<FFaListViewItem*>& items);
 
@@ -146,10 +144,11 @@ private:
   void sortItems(std::vector<FFaListViewItem*>& items) const;
 
   int createSingleUIItem(FFaListViewItem* item,
-			 FFaListViewItem* parent,
-		         FFaListViewItem* after);
+                         FFaListViewItem* parent,
+                         FFaListViewItem* after);
 
-  FFaListViewItem* getItemBefore(FFaListViewItem* item, int itemsUIParent) const;
+  FFaListViewItem* getItemBefore(FFaListViewItem* item,
+                                 int itemsUIParent) const;
 
   void updateLeavesOnlySelectable();
 

--- a/src/vpmApp/vpmAppUAMap/FapUAObjectBrowser.C
+++ b/src/vpmApp/vpmAppUAMap/FapUAObjectBrowser.C
@@ -15,31 +15,19 @@ Fmd_SOURCE_INIT(FAPUAOBJECTBROWSER, FapUAObjectBrowser, FapUAExistenceHandler);
 //----------------------------------------------------------------------------
 
 FapUAObjectBrowser::FapUAObjectBrowser(FuiObjectBrowser* ui)
-  : FapUAExistenceHandler(ui), FapUADataHandler(ui),
+  : FapUAExistenceHandler(ui),
     permSignalConnector(this), modelMemberChangedConnector(this)
 {
   Fmd_CONSTRUCTOR_INIT(FapUAObjectBrowser);
 
-  this->myUI = ui;
-  this->mySelectedFmItem = NULL;
+  myUI = ui;
 
   // Find selection that created this dialog
+  FmModelMemberBase* selectedItem = NULL;
   std::vector<FmModelMemberBase*> objs;
-  FapEventManager::getMMBSelection(objs,mySelectedFmItem);
-  if (!mySelectedFmItem && !objs.empty())
-    mySelectedFmItem = objs.back();
-}
-//----------------------------------------------------------------------------
-
-FFuaUIValues* FapUAObjectBrowser::createValuesObject()
-{
-  return new FuaObjectBrowserValues();
-}
-//----------------------------------------------------------------------------
-
-void FapUAObjectBrowser::getDBValues(FFuaUIValues* values)
-{
-  static_cast<FuaObjectBrowserValues*>(values)->obj = mySelectedFmItem;
+  FapEventManager::getMMBSelection(objs,selectedItem);
+  if (!selectedItem && !objs.empty())
+    myUI->update(objs.back());
 }
 //----------------------------------------------------------------------------
 
@@ -48,17 +36,16 @@ void FapUAObjectBrowser::onPermSelectionChanged(const std::vector<FFaViewItem*>&
                                                 const std::vector<FFaViewItem*>&)
 {
   // Show the last selected model member
-  mySelectedFmItem = NULL;
+  FmModelMemberBase* selectedItem = NULL;
   size_t i = totalSelection.size();
-  while (i > 0 && !mySelectedFmItem)
-    mySelectedFmItem = dynamic_cast<FmModelMemberBase*>(totalSelection[--i]);
+  while (i > 0 && !selectedItem)
+    selectedItem = dynamic_cast<FmModelMemberBase*>(totalSelection[--i]);
 
-  this->updateUI();
+  myUI->update(selectedItem);
 }
 //----------------------------------------------------------------------------
 
 void FapUAObjectBrowser::onModelMemberChanged(FmModelMemberBase* changedObj)
 {
-  if (changedObj == mySelectedFmItem)
-    this->updateUI();
+  myUI->update(changedObj,true);
 }

--- a/src/vpmApp/vpmAppUAMap/FapUAObjectBrowser.H
+++ b/src/vpmApp/vpmAppUAMap/FapUAObjectBrowser.H
@@ -9,14 +9,13 @@
 #define FAP_UA_OBJECT_BROWSER_H
 
 #include "vpmApp/vpmAppUAMap/vpmAppUAMapHandlers/FapUAExistenceHandler.H"
-#include "vpmApp/vpmAppUAMap/vpmAppUAMapHandlers/FapUADataHandler.H"
 #include "vpmApp/FapEventManager.H"
 #include "vpmDB/FmModelMemberConnector.H"
 
 class FuiObjectBrowser;
 
 
-class FapUAObjectBrowser : public FapUAExistenceHandler, public FapUADataHandler
+class FapUAObjectBrowser : public FapUAExistenceHandler
 {
   Fmd_HEADER_INIT();
 
@@ -24,21 +23,14 @@ public:
   FapUAObjectBrowser(FuiObjectBrowser* ui);
   virtual ~FapUAObjectBrowser() {}
 
-protected:
-  // from datahandler
-  virtual FFuaUIValues* createValuesObject();
-  virtual void getDBValues(FFuaUIValues* values);
-
 private:
   void onPermSelectionChanged(const std::vector<FFaViewItem*>& totalSelection,
 			      const std::vector<FFaViewItem*>&,
 			      const std::vector<FFaViewItem*>&);
   void onModelMemberChanged(FmModelMemberBase* changedObj);
 
-  FuiObjectBrowser*  myUI;
-  FmModelMemberBase* mySelectedFmItem;
+  FuiObjectBrowser* myUI;
 
-  // Signal Receivers
   FapPermSelChangedReceiver<FapUAObjectBrowser> permSignalConnector;
   FmModelMemberChangedReceiver<FapUAObjectBrowser> modelMemberChangedConnector;
 

--- a/src/vpmApp/vpmAppUAMap/FapUARDBListView.C
+++ b/src/vpmApp/vpmAppUAMap/FapUARDBListView.C
@@ -106,25 +106,18 @@ void FapUARDBListView::getChildren(FFaListViewItem* parent,
 }
 //----------------------------------------------------------------------------
 
-std::vector<std::string> FapUARDBListView::getItemText(FFaListViewItem* item)
+std::string FapUARDBListView::getItemText(FFaListViewItem* item)
 {
-  std::vector<std::string> text;
+  FFrEntryBase* ffr = static_cast<FFrEntryBase*>(item);
+  if (!ffr->isOG()) return ffr->getDescription();
 
-  FFrEntryBase* ffr = (FFrEntryBase*)item;
-
-  if (ffr->isOG()) {
-    std::string name = ffr->getType();
-    if (ffr->hasUserID())
-      name += FFaNumStr("[%d]",ffr->getUserID());
-    else if (ffr->hasBaseID())
-      name += FFaNumStr("{%d}",ffr->getBaseID());
-    name += " " + ffr->getDescription();
-    text.push_back(name);
-  }
-  else
-    text.push_back(ffr->getDescription());
-
-  return text;
+  std::string name = ffr->getType();
+  if (ffr->hasUserID())
+    name += FFaNumStr("[%d]",ffr->getUserID());
+  else if (ffr->hasBaseID())
+    name += FFaNumStr("{%d}",ffr->getBaseID());
+  name += " " + ffr->getDescription();
+  return name;
 }
 //----------------------------------------------------------------------------
 

--- a/src/vpmApp/vpmAppUAMap/FapUARDBListView.H
+++ b/src/vpmApp/vpmAppUAMap/FapUARDBListView.H
@@ -36,10 +36,9 @@ protected:
   virtual void getChildren(FFaListViewItem* parent,
 			   std::vector<FFaListViewItem*>& children) const;
 
-  virtual std::vector<std::string> getItemText(FFaListViewItem* item);
+  virtual std::string getItemText(FFaListViewItem* item);
   virtual const char** getItemPixmap(FFaListViewItem* item);
 
-private:
   // Reimplementations from FapUACommandHandler
   virtual FFuaUICommands* getCommands();
 

--- a/src/vpmApp/vpmAppUAMap/FapUAResultListView.C
+++ b/src/vpmApp/vpmAppUAMap/FapUAResultListView.C
@@ -292,18 +292,18 @@ bool FapUAResultListView::verifyItem(FFaListViewItem* item)
 }
 //----------------------------------------------------------------------------
 
-Strings FapUAResultListView::getItemText(FFaListViewItem* item)
+std::string FapUAResultListView::getItemText(FFaListViewItem* item)
 {
   if (dynamic_cast<FmRingStart*>(item))
-    return Strings(1,item->getItemName());
+    return item->getItemName();
 
 #ifndef LV_DEBUG
   if (dynamic_cast<FmResultBase*>(item))
     // Try leave out the user ID to clean up the result list view a bit...
-    return Strings(1,item->getItemDescr());
+    return item->getItemDescr();
 #endif
 
-  return Strings(1,FFaNumStr("[%d] ",item->getItemID()) + item->getItemDescr());
+  return FFaNumStr("[%d] ",item->getItemID()) + item->getItemDescr();
 }
 //----------------------------------------------------------------------------
 

--- a/src/vpmApp/vpmAppUAMap/FapUAResultListView.H
+++ b/src/vpmApp/vpmAppUAMap/FapUAResultListView.H
@@ -28,21 +28,21 @@ protected:
   // Reimplementations from FapUAItemsListView
   virtual bool verifyItem(FFaListViewItem* item);
   virtual FFaListViewItem* getParent(FFaListViewItem* item,
-				     const std::vector<int>&) const;
+                                     const std::vector<int>& assID) const;
   virtual void getChildren(FFaListViewItem* parent,
-			   std::vector<FFaListViewItem*>& children) const;
+                           std::vector<FFaListViewItem*>& children) const;
 
-  virtual std::vector<std::string> getItemText(FFaListViewItem* item);
+  virtual std::string getItemText(FFaListViewItem* item);
   virtual const char** getItemPixmap(FFaListViewItem* item);
 
   virtual bool isHeaderOkAsLeaf(FFaListViewItem* item) const;
   virtual bool getItemTextBold(FFaListViewItem* item);
   virtual void dropItems(int droppedOnItemIdx, bool isCopy, void*);
 
-private:
   // Reimplementations from FapUACommandHandler
   virtual FFuaUICommands* getCommands();
 
+private:
   FmRingStart* funcPreviews;
   FmRingStart* beamDiagrams;
 

--- a/src/vpmApp/vpmAppUAMap/FapUASimModelListView.C
+++ b/src/vpmApp/vpmAppUAMap/FapUASimModelListView.C
@@ -233,24 +233,24 @@ void FapUASimModelListView::getChildren(FFaListViewItem* parent,
 }
 //----------------------------------------------------------------------------
 
-std::vector<std::string> FapUASimModelListView::getItemText(FFaListViewItem* item)
+std::string FapUASimModelListView::getItemText(FFaListViewItem* item)
 {
   if (dynamic_cast<FmRingStart*>(item))
-    return std::vector<std::string>(1,item->getItemName());
+    return item->getItemName();
 
 #ifndef LV_DEBUG
   if (dynamic_cast<FmAssemblyBase*>(item) && !dynamic_cast<FmStructAssembly*>(item))
     // Try leave out the user ID for positioned assembly objects
     // (they are normally very few and of different sub-classes
     // which is sufficient for proper identification)
-    return std::vector<std::string>(1,item->getItemDescr());
+    return item->getItemDescr();
 #endif
 
   FFaNumStr txt("[%d]",item->getItemID());
   if (debugMode)
     txt += FFaNumStr("{%d}",item->getItemBaseID());
   txt += " " + item->getItemDescr();
-  return std::vector<std::string>(1,txt);
+  return txt;
 }
 //----------------------------------------------------------------------------
 

--- a/src/vpmApp/vpmAppUAMap/FapUASimModelListView.H
+++ b/src/vpmApp/vpmAppUAMap/FapUASimModelListView.H
@@ -25,12 +25,12 @@ protected:
 				     const std::vector<int>& assID) const;
   virtual void getChildren(FFaListViewItem* parent,
 			   std::vector<FFaListViewItem*>& children) const;
-  virtual std::vector<std::string> getItemText(FFaListViewItem* item);
+  virtual std::string getItemText(FFaListViewItem* item);
 
-private:
   // Reimplementations from FapUACommandHandler
   virtual FFuaUICommands* getCommands();
 
+private:
   FFuaCmdHeaderItem createHeader;
   FFuaCmdHeaderItem createSpringFunctionHeader;
   FFuaCmdHeaderItem createDamperFunctionHeader;

--- a/src/vpmApp/vpmAppUAMap/FapUASimModelRDBListView.C
+++ b/src/vpmApp/vpmAppUAMap/FapUASimModelRDBListView.C
@@ -71,7 +71,7 @@ void FapUASimModelRDBListView::updateSession()
   double usedTime = (stop-start)/((double)CLOCKS_PER_SEC);
   std::cout << this->ui->getName()
 	    <<" - FapUASimModelRDBListView::updateSession() used time: "<< usedTime
-	    <<" nItems:"<< this->ui->getAllChildren(-1).size() << std::endl;
+	    <<" nItems:"<< this->ui->getAllChildren(-1,true).size() << std::endl;
 #endif
 }
 //----------------------------------------------------------------------------
@@ -179,14 +179,14 @@ void FapUASimModelRDBListView::getChildren(FFaListViewItem* parent,
 }
 //----------------------------------------------------------------------------
 
-std::vector<std::string> FapUASimModelRDBListView::getItemText(FFaListViewItem* item)
+std::string FapUASimModelRDBListView::getItemText(FFaListViewItem* item)
 {
   if (dynamic_cast<FFrEntryBase*>(item))
     return FapUARDBListView::getItemText(item);
   else if (dynamic_cast<FmModelMemberBase*>(item))
     return FapUASimModelListView::getItemText(item);
-  else
-    return std::vector<std::string>();
+
+  return "";
 }
 //----------------------------------------------------------------------------
 

--- a/src/vpmApp/vpmAppUAMap/FapUASimModelRDBListView.H
+++ b/src/vpmApp/vpmAppUAMap/FapUASimModelRDBListView.H
@@ -18,13 +18,13 @@ public:
   FapUASimModelRDBListView(FuiItemsListView* ui);
   virtual ~FapUASimModelRDBListView() {}
 
-private:
+protected:
   // Reimplementations from FapUAItemsListView
   virtual bool verifyItem(FFaListViewItem* item);
   virtual void getChildren(FFaListViewItem* parent,
 			   std::vector<FFaListViewItem*>& children) const;
 
-  virtual std::vector<std::string> getItemText(FFaListViewItem* item);
+  virtual std::string getItemText(FFaListViewItem* item);
   virtual const char** getItemPixmap(FFaListViewItem* item);
 
   // Reimplementations from FapUACommandHandler

--- a/src/vpmUI/vpmUIComponents/FuiItemsListView.C
+++ b/src/vpmUI/vpmUIComponents/FuiItemsListView.C
@@ -13,9 +13,12 @@
 bool FuiItemsListView::mouseSelected = false;
 
 
-int FuiItemsListView::createItem(int parent, int after, const char* label)
+int FuiItemsListView::createItem(int parent, int after,
+                                 const std::string& label)
 {
-  return this->createListItem(this->getListItem(parent),this->getListItem(after),NULL,label)->getItemId();
+  return this->createListItem(this->getListItem(parent),
+                              this->getListItem(after),
+                              NULL,label.c_str())->getItemId();
 }
 //----------------------------------------------------------------------------
 
@@ -49,11 +52,9 @@ void FuiItemsListView::setItemSelectAble(int item, bool able)
 }
 //----------------------------------------------------------------------------
 
-void FuiItemsListView::setItemText(int item, const std::vector<std::string>& texts)
+void FuiItemsListView::setItemText(int item, const std::string& text)
 {
-  FFuListViewItem* ffuitem = this->getListItem(item);
-  for (size_t i = 0; i < texts.size(); i++)
-    ffuitem->setItemText(i,texts[i].c_str());
+  this->getListItem(item)->setItemText(0,text.c_str());
 }
 //----------------------------------------------------------------------------
 
@@ -93,7 +94,7 @@ void FuiItemsListView::setItemToggleValue(int item, int value)
 }
 //----------------------------------------------------------------------------
 
-int FuiItemsListView::getItemToggleValue(int item)
+int FuiItemsListView::getItemToggleValue(int item) const
 {
   return this->getListItem(item)->getToggleValue();
 }
@@ -111,7 +112,7 @@ void FuiItemsListView::setItemDragable(int item, bool yesOrNo)
 }
 //----------------------------------------------------------------------------
 
-int FuiItemsListView::getItemPosition(int item)
+int FuiItemsListView::getItemPosition(int item) const
 {
   return this->getListItem(item)->getItemPosition();
 }
@@ -125,7 +126,7 @@ int FuiItemsListView::getItemBefore(int itemsParent, int itemsListPosition)
 }
 //----------------------------------------------------------------------------
 
-int FuiItemsListView::getParent(int item)
+int FuiItemsListView::getParent(int item) const
 {
   FFuListViewItem* parent = this->getListItem(item)->getParentItem();
   return parent ? parent->getItemId() : -1;
@@ -149,13 +150,13 @@ std::vector<int> FuiItemsListView::getChildren(int parent, bool all)
 }
 //----------------------------------------------------------------------------
 
-int FuiItemsListView::getNSiblings(int item)
+int FuiItemsListView::getNSiblings(int item) const
 {
   return this->getListItem(item)->getNSiblings();
 }
 //----------------------------------------------------------------------------
 
-int FuiItemsListView::getNChildren(int item)
+int FuiItemsListView::getNChildren(int item) const
 {
   return this->getListItem(item)->getNChildren();
 }

--- a/src/vpmUI/vpmUIComponents/FuiItemsListView.C
+++ b/src/vpmUI/vpmUIComponents/FuiItemsListView.C
@@ -59,13 +59,13 @@ void FuiItemsListView::setItemText(int item, const std::vector<std::string>& tex
 
 void FuiItemsListView::setItemTextBold(int item, bool bold)
 {
-  this->getListItem(item)->setItemTextBold(bold);
+  this->getListItem(item)->setItemTextBold(0,bold);
 }
 //----------------------------------------------------------------------------
 
 void FuiItemsListView::setItemTextItalic(int item, bool italic)
 {
-  this->getListItem(item)->setItemTextItalic(italic);
+  this->getListItem(item)->setItemTextItalic(0,italic);
 }
 //----------------------------------------------------------------------------
 

--- a/src/vpmUI/vpmUIComponents/FuiItemsListView.C
+++ b/src/vpmUI/vpmUIComponents/FuiItemsListView.C
@@ -16,9 +16,9 @@ bool FuiItemsListView::mouseSelected = false;
 int FuiItemsListView::createItem(int parent, int after,
                                  const std::string& label)
 {
-  return this->createListItem(this->getListItem(parent),
-                              this->getListItem(after),
-                              NULL,label.c_str())->getItemId();
+  return this->createListItem(label.c_str(),
+                              this->getListItem(parent),
+                              this->getListItem(after))->getItemId();
 }
 //----------------------------------------------------------------------------
 

--- a/src/vpmUI/vpmUIComponents/FuiItemsListView.H
+++ b/src/vpmUI/vpmUIComponents/FuiItemsListView.H
@@ -20,7 +20,8 @@ class FFuaCmdItem;
 
 
 class FuiItemsListView : virtual public FFuListView,
-                         public FFuUAExistenceHandler, public FFuUAItemsViewHandler,
+                         public FFuUAExistenceHandler,
+                         public FFuUAItemsViewHandler,
                          public FFuUACommandHandler
 {
 public:
@@ -33,14 +34,14 @@ public:
   void setToggleItemCB(const FFaDynCB2<int,int>& cb) { toggleItemCB = cb; }
   void setDroppedCB(const FFaDynCB3<int,bool,void*>& cb) { droppedCB = cb; }
 
-  int createItem(int parent, int after, const char* label="label");
+  int createItem(int parent, int after, const std::string& label);
 
   // item settings
   void setItemSelectAble(int item, bool able);
   void expandItem(int item, bool expand);// no notify
   void ensureItemVisible(int item);//expands, notify
 
-  void setItemText(int item, const std::vector<std::string>& texts);
+  void setItemText(int item, const std::string& texts);
   void setItemTextBold(int item, bool bold);
   void setItemTextItalic(int item, bool italic);
   void setItemImage(int item, const char** pixmap);
@@ -48,22 +49,20 @@ public:
   void setItemToggleAble(int item, bool able);
   void setItemThreeStepToggleAble(int item, bool able);
   void setItemToggleValue(int item, int value);// no notify
-  int  getItemToggleValue(int item);// no notify
+  int  getItemToggleValue(int item) const;// no notify
 
   void setItemDropable(int item, bool yesOrNo);
   void setItemDragable(int item, bool yesOrNo);
 
   // item relations
-  int  getItemPosition(int item);
-  int  getItemBefore(int itemsParent, int itemsListPosition);
+  int getItemPosition(int item) const;
+  int getItemBefore(int itemsParent, int itemsListPosition);
   // -1 if not found
-  int  getParent(int item);
+  int getParent(int item) const;
   // if parent = -1, top level children
   std::vector<int> getChildren(int parent, bool all = false);
-  // all levels below parent, if parent = -1 all lv
-  std::vector<int> getAllChildren(int parent) { return this->getChildren(parent,true); }
-  int  getNSiblings(int item);
-  int  getNChildren(int item);
+  int getNSiblings(int item) const;
+  int getNChildren(int item) const;
 
   // listview settings
   void setDecoratedRoot(bool decorated);

--- a/src/vpmUI/vpmUIComponents/FuiTopologyView.C
+++ b/src/vpmUI/vpmUIComponents/FuiTopologyView.C
@@ -75,13 +75,12 @@ void FuiTopologyView::setTree(const std::vector<FuiTopologyItem> &topology)
   FFuListViewItem* newItem = NULL;
 
   myView->clearList();
-  myView->setListColumnWidth(0,15);
 
-  int depth = 0, id = 0;
+  int newDepth = 0, id = 0;
   for (const FuiTopologyItem& top : topology)
   {
     parent = after = newItem;
-    for (int deptDiff = depth-top.depth; deptDiff >= 0; deptDiff--)
+    for (int depth = newDepth; depth >= top.depth; depth--)
       if (parent)
       {
         after  = parent;
@@ -95,8 +94,10 @@ void FuiTopologyView::setTree(const std::vector<FuiTopologyItem> &topology)
     newItem->setItemText(2,top.description.c_str());
     myView->openListItem(newItem,true);
 
-    depth = newItem->getDepth();
+    newDepth = newItem->getDepth();
   }
+
+  myView->resizeListColumnsToContents();
 }
 
 FuiTopologyView* FuiTopologyView::getTopologyView()

--- a/src/vpmUI/vpmUIComponents/FuiTopologyView.C
+++ b/src/vpmUI/vpmUIComponents/FuiTopologyView.C
@@ -87,9 +87,8 @@ void FuiTopologyView::setTree(const std::vector<FuiTopologyItem> &topology)
         parent = parent->getParentItem();
       }
 
-    newItem = myView->createListItem(parent,after);
+    newItem = myView->createListItem(top.type.c_str(),parent,after);
     newItem->setItemId(id++);
-    newItem->setItemText(0,top.type.c_str());
     newItem->setItemText(1,top.id.c_str());
     newItem->setItemText(2,top.description.c_str());
     myView->openListItem(newItem,true);

--- a/src/vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtItemsListView.C
+++ b/src/vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtItemsListView.C
@@ -7,20 +7,19 @@
 
 #include <QEvent>
 #include <QDropEvent>
+#include <QStyleFactory>
 
+#include "vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtItemsListView.H"
 #include "FFuLib/FFuQtComponents/FFuQtListViewItem.H"
-#include "FuiQtItemsListView.H"
 
 //----------------------------------------------------------------------------
 
 FuiQtItemsListView::FuiQtItemsListView(QWidget* parent, const char* name)
   : FFuQtListView(parent,1,name)
 {
-  connect(this, SIGNAL(dropped(QDropEvent*)),
-          this, SLOT(onDropped(QDropEvent*)));
-
-  setStyleSheet("selection-color: white;"
-                "selection-background-color: #3399ff;");
+  this->setStyle(QStyleFactory::create("windows")); // enable connector lines
+  this->setStyleSheet("selection-color: white;"
+                      "selection-background-color: #3399ff;");
 }
 //----------------------------------------------------------------------------
 
@@ -57,11 +56,10 @@ bool FuiQtItemsListView::event(QEvent* e)
 }
 //----------------------------------------------------------------------------
 
-void FuiQtItemsListView::onDropped(QDropEvent* e)
+void FuiQtItemsListView::dropEvent(QDropEvent* e)
 {
-  Q3ListViewItem* dropItem = this->itemAt(this->contentsToViewport(e->pos()));
-  FFuQtListViewItem* dropItemFFu = dynamic_cast<FFuQtListViewItem*>(dropItem);
-
-  int itemId = dropItemFFu ? dropItemFFu->getItemId() : -1;
-  this->droppedCB.invoke(itemId, e->dropAction() == Qt::CopyAction, e);
+  QTreeWidgetItem* qtDropItem = this->itemAt(e->pos());
+  FFuQtListViewItem* dropItem = dynamic_cast<FFuQtListViewItem*>(qtDropItem);
+  this->droppedCB.invoke(dropItem ? dropItem->getItemId() : -1,
+                         e->dropAction() & Qt::CopyAction, e);
 }

--- a/src/vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtItemsListView.H
+++ b/src/vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtItemsListView.H
@@ -14,22 +14,20 @@
 class QEvent;
 class QDropEvent;
 
-class FuiQtItemsListView : public FFuQtListView,
-			   virtual public FuiItemsListView
+
+class FuiQtItemsListView : public FFuQtListView, virtual public FuiItemsListView
 {
   Q_OBJECT
 
-public:
-  FuiQtItemsListView(QWidget* parent = NULL,
-		     const char* name="FuiQtItemsListView");
-  virtual ~FuiQtItemsListView() {}
+protected:
+  FuiQtItemsListView(QWidget* parent, const char* name);
 
 private:
   virtual bool event(QEvent* e);
   virtual void setVisible(bool visible);
 
-private slots:
-  void onDropped(QDropEvent* e);
+protected:
+  virtual void dropEvent(QDropEvent* e);
 };
 
 #endif

--- a/src/vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtItemsListViews.C
+++ b/src/vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtItemsListViews.C
@@ -5,14 +5,15 @@
 // This file is part of FEDEM - https://openfedem.org
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <Qt3Support/Q3DragObject>
+#include <QDrag>
 
-#include "FuiQtItemsListViews.H"
+#include "vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtItemsListViews.H"
 
 
 FuiQtSimModelListView::FuiQtSimModelListView(QWidget* parent, const char* name)
   : FuiQtItemsListView(parent,name)
 {
+  this->setSglSelectionMode(false);
   this->initWidgets();
 }
 
@@ -21,14 +22,10 @@ FuiQtSimModelListView::FuiQtSimModelListView(QWidget* parent, const char* name)
 FuiQtResultListView::FuiQtResultListView(QWidget* parent, const char* name)
   : FuiQtItemsListView(parent,name)
 {
-  this->initWidgets();
+  this->setDragEnabled(true);
   this->setAcceptDrops(true);
   this->viewport()->setAcceptDrops(true);
-}
-
-Q3DragObject* FuiQtResultListView::dragObject()
-{
-  return new Q3TextDrag(this,"Hei");
+  this->initWidgets();
 }
 
 //----------------------------------------------------------------------------
@@ -39,22 +36,25 @@ FuiQtRDBListView::FuiQtRDBListView(QWidget* parent, const char* name)
   this->initWidgets();
 }
 
-Q3DragObject* FuiQtRDBListView::dragObject()
-{
-  return new Q3TextDrag(this,"Hei");
-}
-
 //----------------------------------------------------------------------------
 
 FuiQtSimModelRDBListView::FuiQtSimModelRDBListView(QWidget* parent, const char* name)
   : FuiQtItemsListView(parent,name)
 {
+  this->setDragEnabled(true);
   this->initWidgets();
 }
 
-Q3DragObject* FuiQtSimModelRDBListView::dragObject()
+//----------------------------------------------------------------------------
+// This solution was proposed by ChatGPT when asked "How to disable the
+// Qt::MoveAction when dragging an item from one QTreeView to another".
+// Without this, the list item dragged from the SimModelRDBListView will be
+// deleted, which it is not designed for, causing the application to crash.
+void FuiQtSimModelRDBListView::startDrag(Qt::DropActions)
 {
-  return new Q3TextDrag(this,"Hei");
+  QDrag* drag = new QDrag(this);
+  drag->setMimeData(this->model()->mimeData(this->selectedIndexes()));
+  drag->exec(Qt::CopyAction); // Only allow copying, not moving
 }
 
 //----------------------------------------------------------------------------

--- a/src/vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtItemsListViews.H
+++ b/src/vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtItemsListViews.H
@@ -28,7 +28,6 @@ class FuiQtSimModelListView : public FuiQtItemsListView,
 {
 public:
   FuiQtSimModelListView(QWidget* parent, const char* name = "SimModel");
-  virtual ~FuiQtSimModelListView() {}
 };
 
 
@@ -37,10 +36,6 @@ class FuiQtResultListView : public FuiQtItemsListView,
 {
 public:
   FuiQtResultListView(QWidget* parent, const char* name = "Result");
-  virtual ~FuiQtResultListView() {}
-
-protected:
-  virtual Q3DragObject* dragObject();
 };
 
 
@@ -49,10 +44,6 @@ class FuiQtRDBListView : public FuiQtItemsListView,
 {
 public:
   FuiQtRDBListView(QWidget* parent, const char* name = "RDB");
-  virtual ~FuiQtRDBListView() {}
-
-protected:
-  virtual Q3DragObject* dragObject();
 };
 
 
@@ -61,10 +52,9 @@ class FuiQtSimModelRDBListView : public FuiQtItemsListView,
 {
 public:
   FuiQtSimModelRDBListView(QWidget* parent, const char* name = "SimModelRDB");
-  virtual ~FuiQtSimModelRDBListView() {}
-
 protected:
-  virtual Q3DragObject* dragObject();
+  // Need to override this method in order to disable the Move drop action
+  void startDrag(Qt::DropActions) override;
 };
 
 
@@ -73,7 +63,6 @@ class FuiQtCrossSectionListView : public FuiQtItemsListView,
 {
 public:
   FuiQtCrossSectionListView(QWidget* parent, const char* name = "CrossSection");
-  virtual ~FuiQtCrossSectionListView() {}
 };
 
 
@@ -82,7 +71,6 @@ class FuiQtMaterialListView : public FuiQtItemsListView,
 {
 public:
   FuiQtMaterialListView(QWidget* parent, const char* name = "Material");
-  virtual ~FuiQtMaterialListView() {}
 };
 
 #endif

--- a/src/vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtTopologyView.C
+++ b/src/vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtTopologyView.C
@@ -5,6 +5,8 @@
 // This file is part of FEDEM - https://openfedem.org
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <QStyleFactory>
+
 #include "FFuLib/FFuQtComponents/FFuQtListView.H"
 #include "FFuLib/FFuQtComponents/FFuQtFrame.H"
 #include "vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtTopologyView.H"
@@ -20,6 +22,7 @@ FuiQtTopologyView::FuiQtTopologyView(QWidget* parent, const char* name)
   FFuQtListView* qlv;
   myView = qlv = new FFuQtListView(qfr,3);
   qlv->setFocusPolicy(Qt::NoFocus);
+  qlv->setStyle(QStyleFactory::create("windows")); // enable connector lines
 
   this->initWidgets();
 }

--- a/src/vpmUI/vpmUITopLevels/FuiMiniFileBrowser.C
+++ b/src/vpmUI/vpmUITopLevels/FuiMiniFileBrowser.C
@@ -69,9 +69,9 @@ int FuiMiniFileBrowser::createItem(int parent, int after, const std::string& lab
 				   const std::string& size, const std::string& modified,
 				   const char** icon)
 {
-  FFuListViewItem* item = listView->createListItem(listView->getListItem(parent),
-						   listView->getListItem(after),
-						   0, label.c_str());
+  FFuListViewItem* item = listView->createListItem(label.c_str(),
+                                                   listView->getListItem(parent),
+                                                   listView->getListItem(after));
   if (!item) return -1;
 
   item->setItemText(SIZE_COL, size.c_str());

--- a/src/vpmUI/vpmUITopLevels/FuiMiniFileBrowser.C
+++ b/src/vpmUI/vpmUITopLevels/FuiMiniFileBrowser.C
@@ -284,7 +284,6 @@ void FuiMiniFileBrowser::initWidgets()
   listView->setListColumns({"File","Size","Last modified"});
   listView->setListColumnWidth(2, 100);
   listView->setListRootIsDecorated(true);
-  listView->setEnsureVisibleOnExpansion(true);
   listView->setSglSelectionMode(false);
   listView->setHeaderClickEnabled(-1, false);
   listView->setAllListColumnsShowSelection(true);

--- a/src/vpmUI/vpmUITopLevels/FuiMiniFileBrowser.C
+++ b/src/vpmUI/vpmUITopLevels/FuiMiniFileBrowser.C
@@ -145,7 +145,7 @@ bool FuiMiniFileBrowser::isItemPresent(int id)
 bool FuiMiniFileBrowser::isItemExpanded(int id)
 {
   FFuListViewItem* item = listView->getListItem(id);
-  return item ? listView->isExpanded(item) : false;
+  return item ? item->isItemExpanded() : false;
 }
 
 

--- a/src/vpmUI/vpmUITopLevels/FuiObjectBrowser.C
+++ b/src/vpmUI/vpmUITopLevels/FuiObjectBrowser.C
@@ -202,7 +202,7 @@ void FuiObjectBrowser::onSearchViewSelectionChanged()
   std::vector<FFuListViewItem*> lvItems = searchView->getSelectedListItems();
   if (lvItems.empty()) return;
 
-  int nBaseId = atol(lvItems.front()->getItemText(0));
+  int nBaseId = std::stoi(lvItems.front()->getItemText(0));
   FmSimulationModelBase* obj = dynamic_cast<FmSimulationModelBase*>(FmDB::findObject(nBaseId));
   if (obj) outputMemo->setAllText(obj->getObjectInfo().c_str());
 }

--- a/src/vpmUI/vpmUITopLevels/FuiObjectBrowser.C
+++ b/src/vpmUI/vpmUITopLevels/FuiObjectBrowser.C
@@ -158,10 +158,10 @@ void FuiObjectBrowser::onSearchButtonClicked()
   FFuListViewItem* gSubass = NULL;
   if (pszSearch.empty() || FFaUpperCaseString(pszSearch) == "(ALL)") {
     pszSearch.clear();
-    gTriads = searchView->createListItem(0,0,0,"Triads");
-    gParts = searchView->createListItem(0,0,0,"Parts");
-    gResults = searchView->createListItem(0,0,0,"Results");
-    gSubass = searchView->createListItem(0,0,0,"High-level");
+    gTriads  = searchView->createListItem("Triads");
+    gParts   = searchView->createListItem("Parts");
+    gResults = searchView->createListItem("Results");
+    gSubass  = searchView->createListItem("High-level");
   }
 
   // Get all
@@ -177,15 +177,15 @@ void FuiObjectBrowser::onSearchButtonClicked()
 
     // Create list view item
     if ((*it)->isOfType(FmTriad::getClassTypeID()))
-      newItem = searchView->createListItem(gTriads,0);
+      newItem = searchView->createListItem(NULL,gTriads);
     else if ((*it)->isOfType(FmLink::getClassTypeID()))
-      newItem = searchView->createListItem(gParts,0);
+      newItem = searchView->createListItem(NULL,gParts);
     else if ((*it)->isOfType(FmResultBase::getClassTypeID()))
-      newItem = searchView->createListItem(gResults,0);
+      newItem = searchView->createListItem(NULL,gResults);
     else if ((*it)->isOfType(FmSubAssembly::getClassTypeID()))
-      newItem = searchView->createListItem(gSubass,0);
+      newItem = searchView->createListItem(NULL,gSubass);
     else
-      newItem = searchView->createListItem(0,0);
+      newItem = searchView->createListItem();
 
     newItem->setItemText(0,FFaNumStr("%5d",(*it)->getBaseID()).c_str());
     newItem->setItemText(1,(*it)->getIdString().c_str());
@@ -236,7 +236,7 @@ void FuiObjectBrowser::setUIValues(const FFuaUIValues* values)
   searchField->setValue(obj->getUserDescription());
 
   // List view
-  FFuListViewItem* newItem = searchView->createListItem(0,0);
+  FFuListViewItem* newItem = searchView->createListItem();
   newItem->setItemText(0,FFaNumStr("%5d",obj->getBaseID()).c_str());
   newItem->setItemText(1,obj->getIdString().c_str());
   newItem->setItemText(2,obj->getUserDescription().c_str());

--- a/src/vpmUI/vpmUITopLevels/FuiObjectBrowser.C
+++ b/src/vpmUI/vpmUITopLevels/FuiObjectBrowser.C
@@ -12,7 +12,8 @@
 
 #include "vpmDB/FmDB.H"
 #include "vpmDB/FmTriad.H"
-#include "vpmDB/FmLink.H"
+#include "vpmDB/FmBeam.H"
+#include "vpmDB/FmPart.H"
 #include "vpmDB/FmResultBase.H"
 #include "vpmDB/FmSubAssembly.H"
 
@@ -32,6 +33,10 @@ Fmd_SOURCE_INIT(FUI_OBJECTBROWSER,FuiObjectBrowser,FFuTopLevelShell);
 FuiObjectBrowser::FuiObjectBrowser()
 {
   Fmd_CONSTRUCTOR_INIT(FuiObjectBrowser);
+
+  myObj = NULL;
+  lastSorted = -1;
+  sortOrder = false;
 }
 //----------------------------------------------------------------------------
 
@@ -43,12 +48,14 @@ void FuiObjectBrowser::initWidgets()
   this->searchLabel->setLabel("Search and browse objects:");
 
   this->searchField->setValue("(All)");
-  this->searchField->setToolTip("Type a search expression here. See Help for more information.");
+  this->searchField->setToolTip("Type a search expression here.\n"
+                                "See Help for more information.");
   this->searchField->setAcceptedCB(FFaDynCB1M(FuiObjectBrowser,this,
-					      onSearchFieldChanged,char*));
+                                              onSearchFieldChanged,char*));
 
   this->searchButton->setLabel("Search");
-  this->searchButton->setActivateCB(FFaDynCB0M(FuiObjectBrowser,this,onSearchButtonClicked));
+  this->searchButton->setActivateCB(FFaDynCB0M(FuiObjectBrowser,this,
+                                               onSearchButtonClicked));
   this->searchButton->setToolTip("Click to perform search");
 
   this->searchView->clearList();
@@ -56,10 +63,11 @@ void FuiObjectBrowser::initWidgets()
   this->searchView->setListRootIsDecorated(true);
   this->searchView->setAllListColumnsShowSelection(true);
   this->searchView->setHeaderClickEnabled(-1,true);
-  this->searchView->setHeaderOff(true);
-  this->searchView->setListSorting(0,true); // enable sorting
+  this->searchView->setHeaderOff(false);
+  this->searchView->setHeaderClickedCB(FFaDynCB1M(FuiObjectBrowser,this,
+                                                  onHeaderClicked,int));
   this->searchView->setPermSelectionChangedCB(FFaDynCB0M(FuiObjectBrowser,this,
-					      onSearchViewSelectionChanged));
+                                                         onSelectionChanged));
 
   this->outputLabel->setLabel("Object details:");
 
@@ -70,14 +78,16 @@ void FuiObjectBrowser::initWidgets()
   this->closeButton->setActivateCB(FFaDynCB0M(FFuComponentBase,this,popDown));
 
   this->helpButton->setLabel("Help");
-  this->helpButton->setActivateCB(FFaDynCB0M(FuiObjectBrowser,this,onHelpButtonClicked));
+  this->helpButton->setActivateCB(FFaDynCB0M(FuiObjectBrowser,this,
+                                             onHelpButtonClicked));
 
   FFuaPalette pal;
   pal.setStdBackground(211,211,211);
   this->sepLabel->setColors(pal);
 
   this->copyDataButton->setLabel("Copy data");
-  this->copyDataButton->setActivateCB(FFaDynCB0M(FuiObjectBrowser,this,onCopyDataButtonClicked));
+  this->copyDataButton->setActivateCB(FFaDynCB0M(FuiObjectBrowser,this,
+                                                 onCopyDataButtonClicked));
 
   FFuUAExistenceHandler::invokeCreateUACB(this);
 }
@@ -137,7 +147,6 @@ void FuiObjectBrowser::placeWidgets(int width, int height)
 void FuiObjectBrowser::onPoppedUp()
 {
   this->placeWidgets(this->getWidth(),this->getHeight());
-  this->updateUIValues();
 }
 //----------------------------------------------------------------------------
 
@@ -145,23 +154,28 @@ void FuiObjectBrowser::onSearchButtonClicked()
 {
   // Clear
   searchView->clearList();
-  searchView->setHeaderOff(false); // show header
 
   // Get search field
   std::string pszSearch = searchField->getValue();
 
   // Groups
-  FFuListViewItem* newItem = NULL;
   FFuListViewItem* gTriads = NULL;
+  FFuListViewItem* gBeams = NULL;
   FFuListViewItem* gParts = NULL;
   FFuListViewItem* gResults = NULL;
   FFuListViewItem* gSubass = NULL;
   if (pszSearch.empty() || FFaUpperCaseString(pszSearch) == "(ALL)") {
     pszSearch.clear();
-    gTriads  = searchView->createListItem("Triads");
-    gParts   = searchView->createListItem("Parts");
-    gResults = searchView->createListItem("Results");
-    gSubass  = searchView->createListItem("High-level");
+    if (FmDB::hasObjectsOfType(FmTriad::getClassTypeID()))
+      gTriads  = searchView->createListItem("Triads");
+    if (FmDB::hasObjectsOfType(FmPart::getClassTypeID()))
+      gParts   = searchView->createListItem("Parts");
+    if (FmDB::hasObjectsOfType(FmBeam::getClassTypeID()))
+      gBeams   = searchView->createListItem("Beams");
+    if (FmDB::hasObjectsOfType(FmResultBase::getClassTypeID()))
+      gResults = searchView->createListItem("Results");
+    if (FmDB::hasObjectsOfType(FmSubAssembly::getClassTypeID()))
+      gSubass  = searchView->createListItem("High-level");
   }
 
   // Get all
@@ -176,31 +190,38 @@ void FuiObjectBrowser::onSearchButtonClicked()
         continue; // doesn't match
 
     // Create list view item
+    FFuListViewItem* parentItem = NULL;
     if ((*it)->isOfType(FmTriad::getClassTypeID()))
-      newItem = searchView->createListItem(NULL,gTriads);
+      parentItem = gTriads;
+    else if ((*it)->isOfType(FmBeam::getClassTypeID()))
+      parentItem = gBeams;
+    else if ((*it)->isOfType(FmPart::getClassTypeID()))
+      parentItem = gParts;
     else if ((*it)->isOfType(FmLink::getClassTypeID()))
-      newItem = searchView->createListItem(NULL,gParts);
+    {
+      if (!gParts && pszSearch.empty())
+        gParts = searchView->createListItem("Parts");
+      parentItem = gParts;
+    }
     else if ((*it)->isOfType(FmResultBase::getClassTypeID()))
-      newItem = searchView->createListItem(NULL,gResults);
+      parentItem = gResults;
     else if ((*it)->isOfType(FmSubAssembly::getClassTypeID()))
-      newItem = searchView->createListItem(NULL,gSubass);
-    else
-      newItem = searchView->createListItem();
+      parentItem = gSubass;
 
-    newItem->setItemText(0,FFaNumStr("%5d",(*it)->getBaseID()).c_str());
-    newItem->setItemText(1,(*it)->getIdString().c_str());
-    newItem->setItemText(2,(*it)->getUserDescription().c_str());
-    searchView->openListItem(newItem,true);
+    this->addListViewItem(*it,parentItem);
   }
+
+  lastSorted = -1;
+  sortOrder = false;
 }
 //----------------------------------------------------------------------------
 
-void FuiObjectBrowser::onSearchViewSelectionChanged()
+void FuiObjectBrowser::onSelectionChanged()
 {
   this->outputMemo->clearText();
 
   std::vector<FFuListViewItem*> lvItems = searchView->getSelectedListItems();
-  if (lvItems.empty()) return;
+  if (lvItems.empty() || lvItems.front()->getNColumns() < 2) return;
 
   int nBaseId = std::stoi(lvItems.front()->getItemText(0));
   FmSimulationModelBase* obj = dynamic_cast<FmSimulationModelBase*>(FmDB::findObject(nBaseId));
@@ -214,35 +235,52 @@ void FuiObjectBrowser::onHelpButtonClicked()
 }
 //----------------------------------------------------------------------------
 
-FFuaUIValues* FuiObjectBrowser::createValuesObject()
+void FuiObjectBrowser::onHeaderClicked(int col)
 {
-  return new FuaObjectBrowserValues();
+  // Toggle the sort order if clicking the same column twice,
+  // otherwise sort in Ascending order (sortOrder=true).
+  if (col == lastSorted)
+    sortOrder = !sortOrder;
+  else
+  {
+    sortOrder = true;
+    lastSorted = col;
+  }
+  this->searchView->setListSorting(col,sortOrder);
 }
 //----------------------------------------------------------------------------
 
-void FuiObjectBrowser::setUIValues(const FFuaUIValues* values)
+void FuiObjectBrowser::update(FmModelMemberBase* newObj, bool updateCurrent)
 {
+  if (newObj != myObj && updateCurrent)
+    return;
+
   // Clear fields
   this->searchField->setValue("(All)");
   this->searchView->clearList();
-  this->searchView->setHeaderOff(false); // show header
   this->outputMemo->clearText();
 
-  // Get selected item
-  FmModelMemberBase* obj = static_cast<const FuaObjectBrowserValues*>(values)->obj;
-  if (!obj) return;
+  myObj = newObj;
+  if (!myObj) return;
 
   // Search field
-  searchField->setValue(obj->getUserDescription());
+  searchField->setValue(myObj->getUserDescription());
 
   // List view
-  FFuListViewItem* newItem = searchView->createListItem();
+  this->addListViewItem(myObj);
+
+  // Memo field
+  FmSimulationModelBase* simobj = dynamic_cast<FmSimulationModelBase*>(myObj);
+  if (simobj) outputMemo->setAllText(simobj->getObjectInfo().c_str());
+}
+//----------------------------------------------------------------------------
+
+void FuiObjectBrowser::addListViewItem(FmModelMemberBase* obj,
+                                       FFuListViewItem* parent)
+{
+  FFuListViewItem* newItem = searchView->createListItem(NULL,parent);
   newItem->setItemText(0,FFaNumStr("%5d",obj->getBaseID()).c_str());
   newItem->setItemText(1,obj->getIdString().c_str());
   newItem->setItemText(2,obj->getUserDescription().c_str());
   searchView->openListItem(newItem,true);
-
-  // Memo field
-  FmSimulationModelBase* simobj = dynamic_cast<FmSimulationModelBase*>(obj);
-  if (simobj) outputMemo->setAllText(simobj->getObjectInfo().c_str());
 }

--- a/src/vpmUI/vpmUITopLevels/FuiObjectBrowser.H
+++ b/src/vpmUI/vpmUITopLevels/FuiObjectBrowser.H
@@ -10,19 +10,18 @@
 
 #include "FFuLib/FFuBase/FFuTopLevelShell.H"
 #include "FFuLib/FFuBase/FFuUAExistenceHandler.H"
-#include "FFuLib/FFuBase/FFuUADataHandler.H"
 
 class FFuLabel;
 class FFuIOField;
 class FFuPushButton;
 class FFuListView;
+class FFuListViewItem;
 class FFuMemo;
 class FmModelMemberBase;
 
 
 class FuiObjectBrowser : virtual public FFuTopLevelShell,
-			 public FFuUAExistenceHandler,
-			 public FFuUADataHandler
+			 public FFuUAExistenceHandler
 {
   Fmd_HEADER_INIT();
 
@@ -46,11 +45,18 @@ private:
   void onSearchButtonClicked();
   void onSearchFieldChanged(char*) { this->onSearchButtonClicked(); }
   void onHelpButtonClicked();
-  void onSearchViewSelectionChanged();
+  void onSelectionChanged();
+  void onHeaderClicked(int col);
+  void addListViewItem(FmModelMemberBase* obj, FFuListViewItem* parent = NULL);
 
 public:
-  virtual FFuaUIValues* createValuesObject();
-  virtual void setUIValues(const FFuaUIValues* values);
+  void update(FmModelMemberBase* newObj, bool updateCurrent = false);
+
+private:
+  int lastSorted;
+  bool sortOrder;
+
+  FmModelMemberBase* myObj;
 
 protected:
   FFuLabel*           headerImage1;
@@ -66,16 +72,5 @@ protected:
   FFuLabel*           sepLabel;
   FFuPushButton*      copyDataButton;
 };
-////////////////////////////////////////////////////////////////////////////////
-
-class FuaObjectBrowserValues : public FFuaUIValues
-{
-public:
-  FuaObjectBrowserValues() { obj = NULL; }
-  virtual ~FuaObjectBrowserValues() {}
-
-  FmModelMemberBase* obj;
-};
-////////////////////////////////////////////////////////////////////////////////
 
 #endif

--- a/src/vpmUI/vpmUITopLevels/vpmUIQtTopLevels/FuiQtMiniFileBrowser.C
+++ b/src/vpmUI/vpmUITopLevels/vpmUIQtTopLevels/FuiQtMiniFileBrowser.C
@@ -5,6 +5,8 @@
 // This file is part of FEDEM - https://openfedem.org
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <QStyleFactory>
+
 #include "FFuLib/FFuQtComponents/FFuQtMemo.H"
 #include "FFuLib/FFuQtComponents/FFuQtListView.H"
 #include "FFuLib/FFuQtComponents/FFuQtSplitter.H"
@@ -28,8 +30,8 @@ FuiQtMiniFileBrowser::FuiQtMiniFileBrowser(int xpos, int ypos,
   FFuQtListView* qListView = new FFuQtListView(qSplitter);
   FFuQtMemo*     qInfoView = new FFuQtMemo(qSplitter);
 
-  QFont afont("Courier",8);
-  qInfoView->setFont(afont);
+  qListView->setStyle(QStyleFactory::create("windows"));
+  qInfoView->setFont({"Courier",8});
 
   dialogButtons = new FFuQtDialogButtons(this);
 

--- a/src/vpmUI/vpmUITopLevels/vpmUIQtTopLevels/FuiQtObjectBrowser.H
+++ b/src/vpmUI/vpmUITopLevels/vpmUIQtTopLevels/FuiQtObjectBrowser.H
@@ -21,6 +21,9 @@ public:
 
 protected:
   virtual void onCopyDataButtonClicked();
+
+private:
+  virtual void setSensitivity(bool) {} // this dialog should always be sensitive
 };
 
 #endif


### PR DESCRIPTION
The classes `FFuQtListView` and `FFuQtListViewItem` are refactored using the new Qt-classes `QTreeWidget` and `QTreeWidgetItem` classes instad of the old Qt3-support classes. This also involves some cleaning, including removal of dead code for moving list view items.

Note: The copy action is now (with QTreeWidget) is now the default when dragging listview items. The move action is activated by pressing the Shift key while dragging. Before (with Q3ListView), move action was default and copy was activated pressing the Ctrl key. This change needs to be documented.

Also in this PR, the objects browser list view is updated with a new group for Beam objects, to separate them from other parts.
Finally, fixed that this dialog is rendered grey and insensitive, if open while a model with results is loaded.