### PR TITLE
Re-enable viewing of PDF-files (User's and Theory Guide)

### DIFF
--- a/Install/fedem.in
+++ b/Install/fedem.in
@@ -1,4 +1,10 @@
 #!/bin/sh
+# SPDX-FileCopyrightText: 2023 SAP SE
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file is part of FEDEM - https://openfedem.org
+
 # Launcher for the FEDEM GUI on Linux.
 path=`which $0`
 dir=`dirname $path`

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ Unzip this file in an arbitrary location, and execute the file `INSTALL.bat`
 as administrator to install the software on your PC.
 See also [Install/README.txt](Install/README.txt).
 
+The Compiled HTML Help file (Fedem.chm) embedded with the installation
+will normally be blocked by the Windows operation system,
+such that only its table of contents is shown when opening it.
+To avoid this, you may need to unblock it in the file Properties,
+as explained [here](https://support.helpndoc.com/en/support/solutions/articles/43000549682-the-chm-documentation-format-only-displays-the-table-of-contents-without-any-topic-content).
+
 Unless you already have Microsoft Visual Studio installed (2015 or later),
 you may also need to download and install some C++ runtime libraries from
 [Microsoft](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170)

--- a/src/vpmUI/vpmUITopLevels/FuiProperties.C
+++ b/src/vpmUI/vpmUITopLevels/FuiProperties.C
@@ -4527,12 +4527,12 @@ void FuiProperties::updateSubassCoG()
 
 void FuiProperties::showUsersGuide()
 {
-  showPDF("file://Doc/FedemUsersGuide.pdf?page=1");
+  showPDF("file://Doc/FedemUsersGuide.pdf");
 }
 
 void FuiProperties::showTheoryGuide()
 {
-  showPDF("file://Doc/FedemTheoryGuide.pdf?page=1");
+  showPDF("file://Doc/FedemTheoryGuide.pdf");
 }
 
 


### PR DESCRIPTION
Instead of looking for the path of the Acrobat reader executable in the the registry, such that it can by launched through a separate `QProcess`, we now always use `QDesktopServices::openUrl()` to launch the PDF-files, which then will be opened in the default external application for pdf-files. This has the limitation that it is not possible to open the file at a specified page. But this functionality is no longer needed since the Start Guide no longer contains links to User Guide chapters where this feature was used. The (now unused) code for using Acrobat reader is retained though, for a while (it probably won't work with Qt 6).

Also adding a README note on the chm-file and missing licensing info on the new file `Install/fedem.in`.
