### PR TITLE
Windpower dialog cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@
 
 # Open FEDEM Changelog
 
+## [fedem-8.1.0.7] (2025-09-16)
+
+### :rocket: Added
+
+No new features in this release, but the use of Qt layout managers of positioning
+the various GUI components is now complete, also for all the property views.
+
+### :bug: Fixed
+
+- The `Qt6OpenGLWidgets.dll` file is missing in the Windows installation.
+- The GUI freezes when the Airfoil Browser dialog is launched on Windows.
+- Some GUI components appear and disappear instantly when the Dynamics Solver dialog is launched the first time.
+- The "File of type:" menu in the file selection dialog contains "All files (*)" only.
+- When creating a sea wave function, the default function type is wrong (should be Sine).
+- Issue https://github.com/openfedem/fedem-gui/issues/83:
+  Deleting and pasting does not work for Linear derivative functions.
+
 ## [fedem-8.1.0] (2025-07-10)
 
 ### :rocket: Initial release of FEDEM R8.1
@@ -281,3 +298,4 @@ before doing this, as they are not included in the FEDEM distribution:
 [fedem-8.0.9]: https://github.com/openfedem/fedem-gui/compare/fedem-8.0.8...fedem-8.0.9
 [fedem-8.0.9.7]: https://github.com/openfedem/fedem-gui/compare/fedem-8.0.9.2...fedem-8.0.9.7
 [fedem-8.1.0]: https://github.com/openfedem/fedem-gui/compare/fedem-8.0.9...fedem-8.1.0
+[fedem-8.1.9.0]: https://github.com/openfedem/fedem-gui/compare/fedem-8.1.0.7...fedem-8.1.0

--- a/src/FFuLib/FFuCustom/components/BladeDrawer.C
+++ b/src/FFuLib/FFuCustom/components/BladeDrawer.C
@@ -5,41 +5,39 @@
 // This file is part of FEDEM - https://openfedem.org
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <QHBoxLayout>
+
+#include "FFuLib/FFuCustom/components/renderers/BladeView.H"
+#include "FFuLib/FFuCustom/components/renderers/AirfoilView.H"
 #include "FFuLib/FFuCustom/components/BladeDrawer.H"
 
 
-BladeDrawer::BladeDrawer( QWidget* parent) : QWidget(parent){
-	apBlade = NULL;
-	apMainLayout = new QHBoxLayout(this);
-	setLayout(apMainLayout);
+BladeDrawer::BladeDrawer(QWidget* parent) : QWidget(parent)
+{
+  apBlade = NULL;
+  apBladeView = new BladeView(this);
+  apAirfoilView = new AirfoilView(this);
 
-	apBladeView = new BladeView(this);
-	apAirfoilView = new AirfoilView(this);
+  QBoxLayout* layout = new QHBoxLayout(this);
+  layout->setContentsMargins(0,0,0,0);
+  layout->setSpacing(0);
+  layout->addWidget(apBladeView);
+  layout->addWidget(apAirfoilView);
 
-	apMainLayout->addWidget(apBladeView);
-	apMainLayout->addWidget(apAirfoilView);
+  this->setFixedHeight(170);
+  apAirfoilView->setFixedSize(170,160);
+  apBladeView->setFixedHeight(160);
 
-	apBladeView->setFixedHeight(160);
-	apAirfoilView->setFixedSize(170,160);
-
-	setFixedHeight(170);
-	//setFixedWidth(900);
-
-	setStyleSheet("border: 4px solid qradialgradient(cx:0.5, cy:0.5, radius: 1, fx:0.5, fy:0.5, stop:0 #fdd000, stop:1 #f77500); "
-			"border-left: 0px solid; border-right: 0px solid; border-top: 0px solid");
-	apAirfoilView->setStyleSheet("border-left: 2px solid qradialgradient(cx:0.5, cy:0.5, radius: 1, fx:0.5, fy:0.5, stop:0 #fdd000, stop:1 #f77500)");
-
-	apMainLayout->setContentsMargins(0,0,0,0);
-	this->setContentsMargins(0,0,0,0);
-	apMainLayout->setSpacing(0);
+  this->setStyleSheet("border: 4px solid qradialgradient(cx:0.5, cy:0.5, radius: 1, fx:0.5, fy:0.5, stop:0 #fdd000, stop:1 #f77500); "
+                      "border-left: 0px solid; border-right: 0px solid; border-top: 0px solid");
+  apAirfoilView->setStyleSheet("border-left: 2px solid qradialgradient(cx:0.5, cy:0.5, radius: 1, fx:0.5, fy:0.5, stop:0 #fdd000, stop:1 #f77500)");
 }
 
-BladeDrawer::~BladeDrawer(){
-}
 
-void BladeDrawer::setBlade( Blade* aBlade ){
-	apBlade = aBlade;
+void BladeDrawer::setBlade(Blade* aBlade)
+{
+  apBlade = aBlade;
 
-	apBladeView->setBlade(apBlade);
-	apAirfoilView->setBlade(apBlade);
+  apBladeView->setBlade(apBlade);
+  apAirfoilView->setBlade(apBlade);
 }

--- a/src/FFuLib/FFuCustom/components/BladeDrawer.H
+++ b/src/FFuLib/FFuCustom/components/BladeDrawer.H
@@ -9,29 +9,25 @@
 #define BLADE_DRAWER_H
 
 #include <QWidget>
-#include <QHBoxLayout>
 
-#include "FFuLib/FFuCustom/components/Blade.H"
-#include "FFuLib/FFuCustom/components/renderers/BladeView.H"
-#include "FFuLib/FFuCustom/components/renderers/AirfoilView.H"
+class Blade;
+class BladeView;
+class AirfoilView;
 
-class BladeDrawer : public QWidget {
-	Q_OBJECT
 
+class BladeDrawer : public QWidget
+{
 public:
-	BladeDrawer( QWidget *parent=0 );
-	~BladeDrawer();
+  BladeDrawer(QWidget* parent = NULL);
 
-	void setBlade( Blade* aBlade );
-	Blade* getBlade(){ return apBlade; }
+  void setBlade(Blade* aBlade);
+  Blade* getBlade() const { return apBlade; }
 
-	AirfoilView* apAirfoilView;
-	BladeView* apBladeView;
+  AirfoilView* apAirfoilView;
+  BladeView* apBladeView;
+
 private:
-	Blade* apBlade;
-
-	QHBoxLayout* apMainLayout;
-
+  Blade* apBlade;
 };
 
 #endif

--- a/src/FFuLib/FFuCustom/components/CMakeLists.txt
+++ b/src/FFuLib/FFuCustom/components/CMakeLists.txt
@@ -11,7 +11,6 @@ if ( USE_WINDPOW )
   file ( GLOB_RECURSE HPP_HEADER_FILES *.H )
 
   set ( QT_MOC_HEADER_FILES
-	BladeDrawer.H
 	guiComponents/AirfoilSelector.H
 	guiComponents/BladeSelector.H
 	renderers/AirfoilView.H

--- a/src/FFuLib/FFuCustom/components/guiComponents/AirfoilSelector.H
+++ b/src/FFuLib/FFuCustom/components/guiComponents/AirfoilSelector.H
@@ -16,15 +16,13 @@
 
 #include <QWidget>
 
-class QLabel;
-class QComboBox;
 class QRadioButton;
 class QPushButton;
 class QLineEdit;
-class QVBoxLayout;
-class QHBoxLayout;
+class QComboBox;
 class QAbstractItemView;
 class AirfoilSelectionModel;
+class DataNode;
 
 
 class AirfoilSelector : public QWidget
@@ -48,7 +46,6 @@ public:
   void refresh();
 
 private:
-  QLabel* apBanner;
   QComboBox* apAvailableAirfoilsPullDown;
   QRadioButton* apCustomFolderRadioButton;
   QRadioButton* apDefaultFolderRadioButton;
@@ -56,10 +53,6 @@ private:
   QLineEdit* apPathField;
 
   AirfoilSelectionModel* apAirfoilSelectionModel;
-
-  QVBoxLayout* apMainLayout;
-  QVBoxLayout* apButtonLayout;
-  QHBoxLayout* apFolderLayout;
 
   QString customFolder;
   QString standardFolder;
@@ -71,6 +64,9 @@ public slots:
 
 signals:
   void selectionModelChanged();
+
+private:
+  DataNode* getNodeAt(int r, int c) const;
 };
 
 #endif

--- a/src/FFuLib/FFuCustom/components/guiComponents/BladeSelector.H
+++ b/src/FFuLib/FFuCustom/components/guiComponents/BladeSelector.H
@@ -19,9 +19,8 @@
 class QTreeView;
 class QToolButton;
 class QLineEdit;
-class QHBoxLayout;
-class QVBoxLayout;
 class BladeSelectionModel;
+class DataNode;
 
 
 class BladeSelector : public QWidget
@@ -53,9 +52,6 @@ private:
   BladeSelectionModel* apBladeSelectionModel;
   QLineEdit* apPathField;
 
-  QHBoxLayout* apMainLayout;
-  QVBoxLayout* apButtonLayout;
-
   QString propPath;
   QString currentPath;
   bool    expanded;
@@ -68,6 +64,10 @@ public slots:
 
 signals:
   void selectionModelChanged();
+
+private:
+  DataNode* getCurrentNode() const;
+  DataNode* getNodeAt(int r, int c) const;
 };
 
 #endif

--- a/src/FFuLib/FFuCustom/inputTables/InputTable.C
+++ b/src/FFuLib/FFuCustom/inputTables/InputTable.C
@@ -25,90 +25,93 @@
 #include "FFuLib/FFuCustom/inputTables/InputTable.H"
 
 
-InputTable::InputTable(int rows, int columns, TableOrdering orderingType, QWidget* parent) :
-		QWidget(parent)
+InputTable::InputTable(int rows, int cols, TableOrdering oType, QWidget* parent)
+  : QWidget(parent)
 {
-	apTableView = new QTableView();
+  apTableView = new QTableView();
+  apTableView->setAcceptDrops(true);
 
-	apLayout = new QVBoxLayout();
+  QLayout* layout = new QVBoxLayout(this);
+  layout->addWidget(apTableView);
 
-	apTableView->setAcceptDrops(true);
+  // ******* Actions *******
 
-	apLayout->addWidget(apTableView);
-	setLayout(apLayout);
+  // Copy
+  copyAction = new QAction("&Copy",this);
+  copyAction->setShortcut(QKeySequence("Ctrl+c"));
+  QObject::connect(copyAction, SIGNAL(triggered()), this, SLOT(Copy()));
+  apTableView->addAction(copyAction);
 
-	ResizeToContents();
+  // Paste
+  pasteAction = new QAction("&Paste",this);
+  pasteAction->setShortcut(QKeySequence("Ctrl+v"));
+  QObject::connect(pasteAction, SIGNAL(triggered()), this, SLOT(Paste()));
+  apTableView->addAction(pasteAction);
 
-	// ******* Actions *******
-	// Copy
-	copyAction = new QAction("&Copy",this);
-	copyAction->setShortcut(QKeySequence(tr("Ctrl+c")));
-	QObject::connect(copyAction, SIGNAL(activated()), this, SLOT(Copy()) );
-	apTableView->addAction(copyAction);
-	// Paste
-	pasteAction = new QAction("&Paste",this);
-	pasteAction->setShortcut(QKeySequence(tr("Ctrl+v")));
-	QObject::connect(pasteAction, SIGNAL(activated()), this, SLOT(Paste()) );
-	apTableView->addAction(pasteAction);
-	// Delete
-	deleteAction = new QAction("&Delete", this);
-	deleteAction->setShortcut(QKeySequence(tr("delete")));
-	QObject::connect(deleteAction, SIGNAL(activated()), this, SLOT(Delete()) );
-	apTableView->addAction(deleteAction);
-	// Insert row
-	insertRowAction = new QAction("&Insert Row", this);
-	insertRowAction->setShortcut(QKeySequence(tr("Ctrl+i")));
-	QObject::connect(insertRowAction, SIGNAL(activated()), this, SLOT(InsertRow()) );
-	apTableView->addAction(insertRowAction);
-	// Remove row
-	removeRowAction = new QAction("&Remove Row", this);
-	removeRowAction->setShortcut(QKeySequence(tr("Ctrl+r")));
-	QObject::connect(removeRowAction, SIGNAL(activated()), this, SLOT(RemoveRow()) );
-	apTableView->addAction(removeRowAction);
-	// Insert column
-	insertColumnAction = new QAction("&Insert Column", this);
-	insertColumnAction->setShortcut(QKeySequence(tr("Ctrl+k")));
-	QObject::connect(insertColumnAction, SIGNAL(activated()), this, SLOT(InsertColumn()) );
-	apTableView->addAction(insertRowAction);
-	// Remove column
-	removeColumnAction = new QAction("&Remove Column", this);
-	removeColumnAction->setShortcut(QKeySequence(tr("Ctrl+l")));
-	QObject::connect(removeColumnAction, SIGNAL(activated()), this, SLOT(RemoveColumn()) );
-	apTableView->addAction(removeColumnAction);
+  // Delete
+  deleteAction = new QAction("&Delete", this);
+  deleteAction->setShortcut(QKeySequence("delete"));
+  QObject::connect(deleteAction, SIGNAL(triggered()), this, SLOT(Delete()));
+  apTableView->addAction(deleteAction);
 
-	//***************
-	//Create model
-	apTableModel = new TableModel(rows, columns, orderingType);
-	apTableView->setModel(apTableModel);
+  // Insert row
+  insertRowAction = new QAction("&Insert Row", this);
+  insertRowAction->setShortcut(QKeySequence("Ctrl+i"));
+  QObject::connect(insertRowAction, SIGNAL(triggered()), this, SLOT(InsertRow()));
+  apTableView->addAction(insertRowAction);
 
-	// Context menu for table
-	apTableView->setContextMenuPolicy(Qt::CustomContextMenu);
-	QObject::connect(apTableView, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(contextMenuTable(const QPoint &)));
+  // Remove row
+  removeRowAction = new QAction("&Remove Row", this);
+  removeRowAction->setShortcut(QKeySequence("Ctrl+r"));
+  QObject::connect(removeRowAction, SIGNAL(triggered()), this, SLOT(RemoveRow()) );
+  apTableView->addAction(removeRowAction);
 
-	switch(orderingType){
-		case COLUMN_DOMINANT:
-			// Context menu for horizontal header
-			apTableView->horizontalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
-			QObject::connect(apTableView->horizontalHeader(), SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(contextMenuHorizontalHeader(const QPoint &)));
+  // Insert column
+  insertColumnAction = new QAction("&Insert Column", this);
+  insertColumnAction->setShortcut(QKeySequence("Ctrl+k"));
+  QObject::connect(insertColumnAction, SIGNAL(triggered()), this, SLOT(InsertColumn()) );
+  apTableView->addAction(insertRowAction);
 
-			apTableView->verticalHeader()->setSectionsClickable(false);
-			apTableView->verticalHeader()->setSectionResizeMode(QHeaderView::Fixed);
-			break;
-		case ROW_DOMINANT:
-			// Context menu for vertical header
-			apTableView->verticalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
-			QObject::connect(apTableView->verticalHeader(), SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(contextMenuVerticalHeader(const QPoint &)));
+  // Remove column
+  removeColumnAction = new QAction("&Remove Column", this);
+  removeColumnAction->setShortcut(QKeySequence("Ctrl+l"));
+  QObject::connect(removeColumnAction, SIGNAL(triggered()), this, SLOT(RemoveColumn()));
+  apTableView->addAction(removeColumnAction);
 
-			apTableView->horizontalHeader()->setSectionsClickable(false);
-			apTableView->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
-			break;
-	}
-	
-	apTableView->setAlternatingRowColors(true);
+  /***************/
+  // Create model
+  apTableModel = new TableModel(rows, cols, oType);
+  apTableView->setModel(apTableModel);
 
-	apTableView->setLocale(QLocale::C);
+  // Context menu for table
+  apTableView->setContextMenuPolicy(Qt::CustomContextMenu);
+  QObject::connect(apTableView, SIGNAL(customContextMenuRequested(const QPoint&)),
+                   this, SLOT(contextMenuTable(const QPoint&)));
 
-	ResizeToContents();
+  switch(oType) {
+  case COLUMN_DOMINANT:
+    // Context menu for horizontal header
+    apTableView->horizontalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
+    QObject::connect(apTableView->horizontalHeader(), SIGNAL(customContextMenuRequested(const QPoint&)),
+                     this, SLOT(contextMenuHorizontalHeader(const QPoint&)));
+
+    apTableView->verticalHeader()->setSectionsClickable(false);
+    apTableView->verticalHeader()->setSectionResizeMode(QHeaderView::Fixed);
+    break;
+  case ROW_DOMINANT:
+    // Context menu for vertical header
+    apTableView->verticalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
+    QObject::connect(apTableView->verticalHeader(), SIGNAL(customContextMenuRequested(const QPoint&)),
+                     this, SLOT(contextMenuVerticalHeader(const QPoint&)));
+
+    apTableView->horizontalHeader()->setSectionsClickable(false);
+    apTableView->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+    break;
+  }
+
+  apTableView->setAlternatingRowColors(true);
+  apTableView->setLocale(QLocale::C);
+  apTableView->resizeColumnsToContents();
 }
 
 void InputTable::ResizeToContents(){

--- a/src/FFuLib/FFuCustom/inputTables/InputTable.H
+++ b/src/FFuLib/FFuCustom/inputTables/InputTable.H
@@ -14,11 +14,12 @@
 #ifndef INPUT_TABLE_H
 #define INPUT_TABLE_H
 
+#include <QWidget>
+
 #include "FFuLib/FFuCustom/mvcModels/TableModel.H"
 
 class QAction;
 class QTableView;
-class QVBoxLayout;
 
 
 /*!
@@ -30,8 +31,7 @@ class InputTable : public QWidget
   Q_OBJECT
 
 public:
-  InputTable(int rows, int columns, TableOrdering orderingType,
-             QWidget* parent = NULL);
+  InputTable(int rows, int cols, TableOrdering oType, QWidget* parent = NULL);
   virtual ~InputTable() {}
 
   TableModel* GetModel() { return apTableModel; }
@@ -62,9 +62,8 @@ public slots:
   virtual void contextMenuHorizontalHeader(const QPoint& pos);
 
 protected:
-  TableModel*  apTableModel;
-  QTableView*  apTableView;
-  QVBoxLayout* apLayout;
+  TableModel* apTableModel;
+  QTableView* apTableView;
 };
 
 #endif

--- a/src/FFuLib/FFuCustom/mvcModels/TableModel.C
+++ b/src/FFuLib/FFuCustom/mvcModels/TableModel.C
@@ -10,6 +10,7 @@
  *  Created on: Jan 17, 2012
  *      Author: runarhr
  */
+
 #include <QMimeData>
 #include <QRegularExpressionValidator>
 
@@ -50,79 +51,64 @@ TableModel::~TableModel() {
 }
 
 
-int TableModel::rowCount(const QModelIndex &parent) const{
-    Q_UNUSED(parent);
-    switch(aOrder){
-    case ROW_DOMINANT:
-    	return apModelVector->size();
-		break;
-    case COLUMN_DOMINANT:
-    	if(apModelVector->size()){
-    		return apModelVector->at(0)->size();
-    	}
-    	else{
-    		return 0;
-    	}
-		break;
-    default:
-    	return 0;
-    }
+int TableModel::rowCount(const QModelIndex&) const
+{
+  switch (aOrder) {
+  case ROW_DOMINANT:
+    return apModelVector->size();
+  case COLUMN_DOMINANT:
+    if (apModelVector->size())
+      return apModelVector->at(0)->size();
+  }
+  return 0;
 }
 
-int TableModel::columnCount(const QModelIndex &parent) const{
-    Q_UNUSED(parent);
-    switch(aOrder){
-    case ROW_DOMINANT:
-    	if(apModelVector->size()){
-    		return apModelVector->at(0)->size();
-    	}
-    	else{
-    		return 0;
-    	}
-    	return 4;
-    	break;
-    case COLUMN_DOMINANT:
-    	return apModelVector->size(); break;
-    default:
-    	return 0;
-    }
+int TableModel::columnCount(const QModelIndex&) const
+{
+  switch (aOrder) {
+  case COLUMN_DOMINANT:
+    return apModelVector->size();
+  case ROW_DOMINANT:
+    if (apModelVector->size())
+      return apModelVector->at(0)->size();
+  }
+  return 0;
 }
 
-QVariant TableModel::data(const QModelIndex &index, int role) const{
-  	if (!index.isValid())
-        return QVariant();
-
-    if(role == Qt::SizeHintRole){
-    	return aCellSizeHint;
-    }
-
-    // Check if index is outside of model
-    if (index.row() >= rowCount() || index.column() >= columnCount()|| index.row() < 0 || index.column() < 0){
-        return QVariant();
-  	}
-
-  	// Handle roles
-    if (role == Qt::DisplayRole || role == Qt::EditRole) {
-    	switch(aOrder){
-    	case ROW_DOMINANT:
-			return apModelVector->at(index.row())->at(index.column()); break;
-    	case COLUMN_DOMINANT:
-    		return apModelVector->at(index.column())->at(index.row()); break;
-    	}
-    }
-    else if(role == Qt::TextAlignmentRole ){
-    	return QVariant(Qt::AlignRight);
-    }
-    else if(role == Qt::ToolTipRole) {
-    	switch(aOrder){
-    	case ROW_DOMINANT:
-			return apModelVector->at(index.row())->at(index.column()); break;
-    	case COLUMN_DOMINANT:
-    		return apModelVector->at(index.column())->at(index.row()); break;
-    	}
-    }
-
+QVariant TableModel::data(const QModelIndex& index, int role) const
+{
+  if (!index.isValid())
     return QVariant();
+
+  if (role == Qt::SizeHintRole)
+    return aCellSizeHint;
+
+  int irow = index.row();
+  int icol = index.column();
+  if (irow >= 0 && icol >= 0)
+    switch (role) {
+    case Qt::DisplayRole:
+    case Qt::EditRole:
+    case Qt::ToolTipRole:
+      switch (aOrder) {
+      case ROW_DOMINANT:
+        if (irow < apModelVector->size())
+          if (icol < apModelVector->at(irow)->size())
+            return apModelVector->at(irow)->at(icol);
+        break;
+      case COLUMN_DOMINANT:
+        if (icol < apModelVector->size())
+          if (irow < apModelVector->at(icol)->size())
+            return apModelVector->at(icol)->at(irow);
+        break;
+      }
+      break;
+
+    case Qt::TextAlignmentRole:
+      return QVariant(Qt::AlignRight);
+    }
+
+  return QVariant();
 }
 
 QVariant TableModel::headerData(int section, Qt::Orientation orientation, int role) const{

--- a/src/FFuLib/FFuCustom/mvcModels/TableModel.H
+++ b/src/FFuLib/FFuCustom/mvcModels/TableModel.H
@@ -11,32 +11,31 @@
  *      Author: runarhr
  */
 
-#ifndef TABLEMODEL_HPP
-#define TABLEMODEL_HPP
+#ifndef TABLE_MODEL_HPP
+#define TABLE_MODEL_HPP
 
+#include <QSize>
 #include <QVector>
 #include <QVariant>
-#include <QStandardItem>
 #include <QAbstractTableModel>
-#include <QPushButton>
-#include <QDoubleValidator>
 
 class QRegularExpressionValidator;
 
 
-enum TableOrdering{ ROW_DOMINANT, COLUMN_DOMINANT};
+enum TableOrdering { ROW_DOMINANT, COLUMN_DOMINANT};
 
 class TableModel : public QAbstractTableModel
 {
-	Q_OBJECT
-public:
-    TableModel(int rows, int columns, TableOrdering order, QObject *parent=0);
-	virtual ~TableModel();
+  Q_OBJECT
 
-	//! Inherited from QAbstractTableModel
-    int rowCount(const QModelIndex &parent = QModelIndex()) const;
-    int columnCount(const QModelIndex &parent = QModelIndex()) const;
-    Qt::ItemFlags flags(const QModelIndex &index) const;
+public:
+  TableModel(int rows, int columns, TableOrdering order, QObject* parent=NULL);
+  virtual ~TableModel();
+
+  //! Inherited from QAbstractTableModel
+  int rowCount(const QModelIndex& = QModelIndex()) const override;
+  int columnCount(const QModelIndex& = QModelIndex()) const override;
+  Qt::ItemFlags flags(const QModelIndex& index) const override;
 
     bool insertRow(int row, const QModelIndex &parent = QModelIndex());
     bool insertRows(int row, int count, const QModelIndex & parent = QModelIndex());

--- a/src/vpmUI/vpmUITopLevels/vpmUIQtTopLevels/FuiQtAirfoilDefinition.H
+++ b/src/vpmUI/vpmUITopLevels/vpmUIQtTopLevels/FuiQtAirfoilDefinition.H
@@ -8,48 +8,29 @@
 #ifndef FUI_QT_AIRFOIL_DEFINITION_H
 #define FUI_QT_AIRFOIL_DEFINITION_H
 
-#include <QHBoxLayout>
-#include <QVBoxLayout>
-#include <QPushButton>
-#include <QLineEdit>
-#include <QLabel>
-#include <QSplitter>
-#include <QSignalMapper>
-
 #include "FFuLib/FFuQtBaseClasses/FFuQtTopLevelShell.H"
 #include "vpmUI/vpmUITopLevels/FuiAirfoilDefinition.H"
-#include "FFuLib/FFuCustom/inputTables/InputTable.H"
-#include "FFuLib/FFuCustom/components/guiComponents/AirfoilSelector.H"
+
+class AirfoilSelector;
+class InputTable;
+class QPushButton;
+class QLineEdit;
+class QSignalMapper;
 
 
-class FuiQtAirfoilDefinition : public FFuQtTopLevelShell, public FuiAirfoilDefinition
+class FuiQtAirfoilDefinition : public FFuQtTopLevelShell,
+                               public FuiAirfoilDefinition
 {
   Q_OBJECT
 
 public:
-  FuiQtAirfoilDefinition(QWidget* parent = 0,
-			 int xpos =100, int ypos =100,
-			 int width=100, int height=100,
-			 const char* title= "Fedem",
-			 const char* name = "FuiQtAirfoilDefinition");
-  virtual ~FuiQtAirfoilDefinition() {}
+  FuiQtAirfoilDefinition(int xpos, int ypos, int width, int height,
+                         const char* title, const char* name);
 
 private:
-	typedef InputTable TableT;
-
 	// Widgets
-	TableT* apAirfoilTable;
+	InputTable*      apAirfoilTable;
 	AirfoilSelector* apAirfoilSelector;
-
-	QSplitter* apSplitter;
-	QWidget* apBottomContainer;
-
-	QLabel* apNameLabel;
-	QLineEdit* apAirfoilName;
-
-	QLabel* apNotesLabel;
-	QLabel* apNotesLabelImage;
-	QLabel* apNotesText;
 
 	//Buttons
 	QPushButton* apAddRowButton;
@@ -64,59 +45,36 @@ private:
 	QSignalMapper* apLineEditMapper;
 
 	//Line edits
-	QLabel* apNumLabel;
 	QLineEdit* apNumEdit;
-	QLabel* apIDLabel;
 	QLineEdit* apIDEdit;
-	QLabel* apStallLabel;
 	QLineEdit* apStallEdit;
-	QLabel* apCnAnglekLabel;
 	QLineEdit* apCnAngleEdit;
-	QLabel* apCnSlopeLabel;
 	QLineEdit* apCnSlopeEdit;
-	QLabel* apCnExtrapolLabel;
 	QLineEdit* apCnExtrapolEdit;
-	QLabel* apCnStallLabel;
 	QLineEdit* apCnStallEdit;
-	QLabel* apAttackLabel;
 	QLineEdit* apAttackEdit;
-	QLabel* apMinCDLabel;
 	QLineEdit* apMinCDEdit;
-
-	//Layouts
-	QVBoxLayout* apMainLayout;
-	QHBoxLayout* apContentLayout;
-	QVBoxLayout* apLineEditLayout;
-	QHBoxLayout* apTableButtonLayout;
-	QVBoxLayout* apTableLayout;
-	QHBoxLayout* apDialogButtonLayout;
-	QHBoxLayout* apNotesLabelLayout;
-	QVBoxLayout* apNotesLayout;
 
 	bool currentAirfoilTouched;
 	QString currentAirfoil;
 
-	void showEvent ( QShowEvent * pEvent );
-	void closeEvent ( QCloseEvent * pEvent );
-
 	void connections();
 
-	void setCurrentAirfoil(QString airfoilPath);
+  void setCurrentAirfoil(const QString& airfoilPath);
+  bool saveAirfoil(const QString& airfoilPath);
 
-	virtual void setSensitivity(bool) {}
+  virtual void showEvent(QShowEvent*);
+  virtual void closeEvent(QCloseEvent* event);
+  virtual void setSensitivity(bool) {}
 
-public slots:
+private slots:
 	void insertSegment();
 	void removeSegment();
 	void acceptClicked();
 	void createAirfoil();
-
 	void airfoilSelected();
-	bool save(QString airfoilPath);
 	void currentModelChanged();
-
-private slots:
-	void lineEditChanged(int lineEdit);
+	void lineEditChanged(int) { this->currentModelChanged(); }
 	void help();
 };
 

--- a/src/vpmUI/vpmUITopLevels/vpmUIQtTopLevels/FuiQtBladeDefinition.H
+++ b/src/vpmUI/vpmUITopLevels/vpmUIQtTopLevels/FuiQtBladeDefinition.H
@@ -8,15 +8,6 @@
 #ifndef FUI_QT_BLADE_DEFINITION_H
 #define FUI_QT_BLADE_DEFINITION_H
 
-#include <QHBoxLayout>
-#include <QVBoxLayout>
-#include <QLabel>
-#include <QPushButton>
-#include <QCheckBox>
-#include <QComboBox>
-#include <QLineEdit>
-#include <QSignalMapper>
-
 #include "FFuLib/FFuQtBaseClasses/FFuQtTopLevelShell.H"
 #include "vpmUI/vpmUITopLevels/FuiBladeDefinition.H"
 
@@ -25,18 +16,23 @@ class Blade;
 class BladeDrawer;
 class BladeSelector;
 class FileFieldDelegate;
+class QPushButton;
+class QCheckBox;
+class QComboBox;
+class QLineEdit;
+class QSignalMapper;
+class QTabWidget;
 
 
-class FuiQtBladeDefinition: public FFuQtTopLevelShell,
-		public FuiBladeDefinition {
-Q_OBJECT
+class FuiQtBladeDefinition : public FFuQtTopLevelShell,
+                             public FuiBladeDefinition
+{
+  Q_OBJECT
+
 public:
-	FuiQtBladeDefinition(QWidget* parent = 0,
-			int xpos =100, int ypos =100,
-			int width=100, int height=100,
-			const char* title= "Fedem",
-			const char* name = "FuiQtBladeDefinition");
-	~FuiQtBladeDefinition();
+  FuiQtBladeDefinition(int xpos, int ypos, int width, int height,
+                       const char* title, const char* name);
+  ~FuiQtBladeDefinition();
 
 private:
 	//**********Widgets**********
@@ -44,12 +40,7 @@ private:
 	BladeDrawer* apBladeDrawer;
 	QTabWidget* apTabWidget;
 
-	QLabel* apNameLabel;
 	QLineEdit* apNameEdit;
-
-	QLabel* apNotesLabel;
-	QLabel* apNotesLabelImage;
-	QLabel* apNotesText;
 
 	BladeSelector* apBladeSelector;
 
@@ -68,18 +59,6 @@ private:
 
 	QWidget* apStructureTab;
 
-	//**********Layouts**********
-	QVBoxLayout* apMainLayout;
-	QVBoxLayout* apStiffnessLayout;
-
-	QHBoxLayout* apViewLayout;
-	QHBoxLayout* apBladeSelectorLayout;
-	QHBoxLayout* apDialogButtonLayout;
-	QHBoxLayout* apCheckBoxLayout;
-
-	QHBoxLayout* apNotesLabelLayout;
-	QVBoxLayout* apNotesLayout;
-
 	InputTable* apAerodynamicTable;
 	InputTable* apStructureTable;
 
@@ -95,10 +74,9 @@ private:
 	bool saveBlade(Blade* blade);
 	void resolveAirfoils(Blade* pBlade);
 
-	void showEvent ( QShowEvent * pEvent );
-	void closeEvent ( QCloseEvent * pEvent );
-
-	virtual void setSensitivity(bool) {}
+  virtual void showEvent(QShowEvent*);
+  virtual void closeEvent(QCloseEvent* event);
+  virtual void setSensitivity(bool) {}
 
 public slots:
 	void initializeBlades();

--- a/src/vpmUI/vpmUITopLevels/vpmUIQtTopLevels/FuiQtTurbWind.C
+++ b/src/vpmUI/vpmUITopLevels/vpmUIQtTopLevels/FuiQtTurbWind.C
@@ -8,8 +8,7 @@
 #include "vpmUI/vpmUITopLevels/vpmUIQtTopLevels/FuiQtTurbWind.H"
 #include "vpmUI/Fui.H"
 #include "vpmUI/Pixmaps/turbWind.xpm"
-
-extern const char* info_xpm[];
+#include "FFuLib/FFuQtComponents/FFuQtLabel.H"
 
 #include <QStandardPaths>
 #include <QComboBox>
@@ -117,20 +116,9 @@ FuiQtTurbWind::FuiQtTurbWind(int xpos, int ypos, int width, int height,
   cmbIECturbc->setGeometry(100, 200, 126, 22);
   cmbIECturbc->setEditable(true);
 
-  label = new QLabel(frmTurbSpc);
-  label->setObjectName("labInfoA1");
-  label->setGeometry(10, 229, 21, 16);
-  label->setPixmap(QPixmap(info_xpm));
-  label = new QLabel(frmTurbSpc);
-  label->setObjectName("labInfoA2");
-  label->setGeometry(30, 231, 46, 13);
-  label->setText("<b>Note</b>");
-
-  QLabel* labInfoA3 = new QLabel(frmTurbSpc);
+  FFuQtNotes* labInfoA3 = new FFuQtNotes(frmTurbSpc);
   labInfoA3->setObjectName("labInfoA3");
-  labInfoA3->setGeometry(10, 244, 231, 65);
-  labInfoA3->setAlignment(Qt::AlignJustify | Qt::AlignVCenter);
-  labInfoA3->setWordWrap(true);
+  labInfoA3->setGeometry(10, 230, 245, 90);
 
   QGroupBox* frmGenerate = new QGroupBox(this);
   frmGenerate->setObjectName("frmGenerate");
@@ -213,20 +201,9 @@ FuiQtTurbWind::FuiQtTurbWind(int xpos, int ypos, int width, int height,
   btnHelp->setObjectName("btnHelp");
   btnHelp->setGeometry(480, 410, 91, 26);
 
-  label = new QLabel(this);
-  label->setObjectName("labInfoB1");
-  label->setGeometry(280, 332, 21, 16);
-  label->setPixmap(QPixmap(info_xpm));
-  label = new QLabel(this);
-  label->setObjectName("labInfoB2");
-  label->setGeometry(300, 334, 46, 13);
-  label->setText("<b>Note</b>");
-
-  QLabel* labInfoB3 = new QLabel(this);
+  FFuQtNotes* labInfoB3 = new FFuQtNotes(this);
   labInfoB3->setObjectName("labInfoB3");
-  labInfoB3->setGeometry(280, 347, 301, 65);
-  labInfoB3->setAlignment(Qt::AlignJustify | Qt::AlignVCenter);
-  labInfoB3->setWordWrap(false);
+  labInfoB3->setGeometry(280, 333, 300, 90);
 
   textEdit = new QTextEdit(this);
   textEdit->setObjectName("textEdit");
@@ -290,7 +267,7 @@ FuiQtTurbWind::FuiQtTurbWind(int xpos, int ypos, int width, int height,
 "<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\">\n"
 "p, li { white-space: pre-wrap; }\n"
 "</style></head><body style=\" font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;\">\n"
-"<p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" font-size:8pt;\">Please fill in the fields above before generating a wind file.</span></p>\n"
+"<p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" font-size:8pt;\">Fill in the fields above before generating a wind file.</span></p>\n"
 "<p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" font-size:8pt;\">- The template file is copied and filled in by this tool.</span></p>\n"
 "<p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" font-size:8pt;\">- The output folder receives all output from the tool.</span></p>\n"
 "<p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" font-size:8pt;\">- Additional parameters are available in the template file.</span></p>\n"


### PR DESCRIPTION
* Replacing a lot of class members by local temporaries in the constructors.
* Using the `FFuQtNotes` class.
* Fix two crashes on Linux when the Airfoil database is not found.
* Avoid that the GUI freezes when launching the Airfoil selector dialog on Windows.