### PR TITLE
Fix missing mesh lines and reduced surface model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 # Open FEDEM Changelog
 
-## [fedem-8.1.6] (2026-04-07)
+## [fedem-8.1.6] (2026-04-23)
 
 ### :rocket: Added
 
@@ -17,6 +17,11 @@
 - Issue https://github.com/openfedem/fedem-gui/issues/139:
   Also write relative distance in the three global axis directions
   when measuring distance between two picked points.
+
+### :bug: Fixed
+
+- Issue https://github.com/openfedem/fedem-gui/issues/143:
+  The reduced surface and mesh lines visualization does not work (bug in R8.1.5 only).
 
 ## [fedem-8.1.5] (2026-03-13)
 

--- a/src/vpmApp/vpmAppCmds/FapCreateSensorCmd.H
+++ b/src/vpmApp/vpmAppCmds/FapCreateSensorCmd.H
@@ -35,11 +35,11 @@ private:
                               const std::vector<FFaViewItem*>&,
                               const std::vector<FFaViewItem*>&);
 
-  FmEngine* myEngine;
-  int       myArg;
-
   FapPermSelChangedReceiver<FapCreateSensorCmd> permSignalConnector;
   friend class FapPermSelChangedReceiver<FapCreateSensorCmd>;
+
+  FmEngine* myEngine;
+  int       myArg;
 };
 
 #endif

--- a/src/vpmDisplay/FdFEGroupPartKit.C
+++ b/src/vpmDisplay/FdFEGroupPartKit.C
@@ -216,19 +216,8 @@ void FdFEGroupPartKit::generateShapeIndexes()
 
   SoIndexedShape* aShape = this->getShape(!myGroupPartData->isLineShape);
 
-  // Calculate needed storage from input
-
-  int nIndexEntries = 0;
-  if (myGroupPartData->isIndexShape)
-    for (const IntVec& shape : myGroupPartData->shapeIndexes)
-      nIndexEntries += shape.size() + 1;
-  else if (myGroupPartData->isLineShape)
-    nIndexEntries = myGroupPartData->edgePointers.size()*3;
-  else
-    nIndexEntries = myGroupPartData->facePointers.size() + myGroupPartData->nVisiblePrimitiveVertexes;
-
   // Set the face indexes into the shape node
-  aShape->coordIndex.setNum(nIndexEntries);
+  aShape->coordIndex.setNum(myGroupPartData->getNoVisibleVertices(true));
   myGroupPartData->getShapeIndexes(aShape->coordIndex.startEditing());
   aShape->coordIndex.finishEditing();
 }
@@ -419,10 +408,7 @@ void FdFEGroupPartKit::remapLookResults(ResultsFrame* frame, const FFaLegendMapp
           nColors = myGroupPartData->facePointers.size();
         break;
       case PR_FACE_VERTEX:
-        if (myGroupPartData->isLineShape)
-          nColors = myGroupPartData->edgePointers.size()*2;
-        else
-          nColors = myGroupPartData->nVisiblePrimitiveVertexes;
+        nColors = myGroupPartData->getNoVisibleVertices();
         break;
       default:
         break;
@@ -514,16 +500,8 @@ float FdFEGroupPartKit::getResultFromMaterialIndex(unsigned int matIdx) const
         break;
 
       case PR_FACE_VERTEX:
-        if (myGroupPartData->isLineShape)
-        {
-          if (matIdx < myGroupPartData->edgePointers.size()*2)
-            resIdx = matIdx;
-        }
-        else
-        {
-          if ((int)matIdx < myGroupPartData->nVisiblePrimitiveVertexes)
-            resIdx = matIdx;
-        }
+        if (matIdx < myGroupPartData->getNoVisibleVertices())
+          resIdx = matIdx;
         break;
 
       default:


### PR DESCRIPTION
This fixes #143 through the submodule update.
It was not only the mesh lines that were missing, if used in Reduced surface option also the surfaces are gone.