### PR TITLE
Avoid multiple differentiation of component curve data

### DIFF
--- a/src/vpmApp/vpmAppCmds/FapCmdsBase.H
+++ b/src/vpmApp/vpmAppCmds/FapCmdsBase.H
@@ -19,8 +19,8 @@ class FuiGraphView;
 class FFaViewItem;
 class FmPart;
 class FmElementGroupProxy;
-
-typedef std::map< FmPart*, std::vector<FmElementGroupProxy*> > FapPartGroupsMap;
+using FapGroupVec = std::vector<FmElementGroupProxy*>;
+using FapPartGroupsMap = std::map<FmPart*,FapGroupVec>;
 
 
 class FapCmdsBase
@@ -32,7 +32,6 @@ protected:
   static FuiGraphView* getActiveGraphView();
 
   // for setGetSensitivityCB
-  static void alwaysSensitive(bool& sens) { sens = true; }
   static void isProEdition(bool& isPro);
   static void isModellerActive(bool& active);
   static void isCtrlModellerActive(bool& active);

--- a/src/vpmApp/vpmAppCmds/FapExportCmds.C
+++ b/src/vpmApp/vpmAppCmds/FapExportCmds.C
@@ -94,15 +94,31 @@ namespace Fap {
 #endif
 }
 
-
-//! map/set sorting
-struct idSort
-{
-  bool operator()(const FmBase* fm1, const FmBase* fm2) const
+namespace {
+  struct idSort
   {
-    return (fm1->getID() < fm2->getID());
+    bool operator()(const FmBase* fm1, const FmBase* fm2) const
+    {
+      return (fm1->getID() < fm2->getID());
+    }
+  };
+
+  FFuFileDialog* saveFile(const char* title = NULL)
+  {
+    return FFuFileDialog::create(FmDB::getMechanismObject()->getAbsModelFilePath(),
+                                 title, FFuFileDialog::FFU_SAVE_FILE, true);
   }
-};
+
+  void writeMetaData(std::ostream& os, const std::string& fileName)
+  {
+    os <<"# Fedem version: "<< FFaAppInfo::getVersion()
+       <<"\n# Model file: "<< FmDB::getMechanismObject()->getModelFileName()
+       <<"\n# This file: "<< fileName
+       <<"\n# Exported by: "<< FFaAppInfo::getUser()
+       <<", "<< FFaAppInfo::getDate()
+       <<"\n#\n";
+  }
+}
 
 //------------------------------------------------------------------------------
 
@@ -181,13 +197,11 @@ void FapExportCmds::init()
   cmdItem->setText("Export model to CGeo...");
   cmdItem->setToolTip("Export model to CGe");
   cmdItem->setActivatedCB(FFaDynCB0S(FapExportCmds::exportCGeo));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_export_dtsDigitalTwin");
   cmdItem->setText("Export Digital Twin...");
   cmdItem->setToolTip("Export current model to a zip'ed Digital Twin");
   cmdItem->setActivatedCB(FFaDynCB0S(FapExportCmds::exportDigitalTwin));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_export_pipeStringWear");
   cmdItem->setText("Export Pipe String Wear...");
@@ -198,14 +212,6 @@ void FapExportCmds::init()
 #else
   cmdItem->setGetSensitivityCB(FFaDynCB1S([](bool& s){ s = false; },bool&));
 #endif
-}
-
-//------------------------------------------------------------------------------
-
-static FFuFileDialog* saveFile(const char* title = NULL)
-{
-  return FFuFileDialog::create(FmDB::getMechanismObject()->getAbsModelFilePath(),
-                               title, FFuFileDialog::FFU_SAVE_FILE, true);
 }
 
 //------------------------------------------------------------------------------
@@ -844,17 +850,6 @@ bool FapExportCmds::exportGraph(const std::vector<FmCurveSet*>& curves,
 #else
   return false;
 #endif
-}
-
-//------------------------------------------------------------------------------
-
-static void writeMetaData(std::ostream& os, const std::string& fileName)
-{
-  FFaAppInfo current;
-  os <<"# Fedem version: "<< current.version <<"\n";
-  os <<"# Model file: "<< FmDB::getMechanismObject()->getModelFileName() <<"\n";
-  os <<"# This file: "<< fileName <<"\n";
-  os <<"# Exported by: "<< current.user <<", "<< current.date <<"\n#\n";
 }
 
 //------------------------------------------------------------------------------

--- a/src/vpmApp/vpmAppCmds/FapLinkVisualCmds.C
+++ b/src/vpmApp/vpmAppCmds/FapLinkVisualCmds.C
@@ -38,13 +38,11 @@ void FapLinkVisualCmds::init()
   cmdItem->setText("Show Subassembly Parts");
   cmdItem->setToolTip("Show the parts in the selected subassembly");
   cmdItem->setActivatedCB(FFaDynCB0S([](){ FapLinkVisualCmds::subassemblySelection(true); }));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_SubassemblySelection_hide");
   cmdItem->setText("Hide Subassembly Parts");
   cmdItem->setToolTip("Hides the parts in the selected subassembly");
   cmdItem->setActivatedCB(FFaDynCB0S([](){ FapLinkVisualCmds::subassemblySelection(false); }));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 }
 
 

--- a/src/vpmApp/vpmAppCmds/FapMainWinCmds.C
+++ b/src/vpmApp/vpmAppCmds/FapMainWinCmds.C
@@ -25,7 +25,6 @@ void FapMainWinCmds::init()
   cmdItem->setToolTip("Model Manager");
   cmdItem->setToggledCB(FFaDynCB1S(FapMainWinCmds::showModelManager,bool));
   cmdItem->setGetToggledCB(FFaDynCB1S(FapMainWinCmds::getModelManagerToggle,bool&));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_mainWin_showProperties");
   cmdItem->setSmallIcon(propertyEditor_xpm);
@@ -33,77 +32,66 @@ void FapMainWinCmds::init()
   cmdItem->setToolTip("Property Editor");
   cmdItem->setToggledCB(FFaDynCB1S(FapMainWinCmds::showProperties,bool));
   cmdItem->setGetToggledCB(FFaDynCB1S(FapMainWinCmds::getPropertiesToggle,bool&));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_mainWin_showStdToolBar");
   cmdItem->setText("Standard");
   cmdItem->setToolTip("Standard");
   cmdItem->setToggledCB(FFaDynCB1S(FapMainWinCmds::showStdToolBar,bool));
   cmdItem->setGetToggledCB(FFaDynCB1S(FapMainWinCmds::getStdToolBarToggle,bool&));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_mainWin_showWindowsToolBar");
   cmdItem->setText("Windows");
   cmdItem->setToolTip("Windows");
   cmdItem->setToggledCB(FFaDynCB1S(FapMainWinCmds::showWindowsToolBar,bool));
   cmdItem->setGetToggledCB(FFaDynCB1S(FapMainWinCmds::getWindowsToolBarToggle,bool&));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_mainWin_showSolveToolBar");
   cmdItem->setText("Solve");
   cmdItem->setToolTip("Solve");
   cmdItem->setToggledCB(FFaDynCB1S(FapMainWinCmds::showSolveToolBar,bool));
   cmdItem->setGetToggledCB(FFaDynCB1S(FapMainWinCmds::getSolveToolBarToggle,bool&));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_mainWin_showViewCtrlToolBar");
   cmdItem->setText("View Control");
   cmdItem->setToolTip("View Control");
   cmdItem->setToggledCB(FFaDynCB1S(FapMainWinCmds::showViewCtrlToolBar,bool));
   cmdItem->setGetToggledCB(FFaDynCB1S(FapMainWinCmds::getViewCtrlToolBarToggle,bool&));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_mainWin_showThreeDViewsToolBar");
   cmdItem->setText("3D Views");
   cmdItem->setToolTip("3D Views");
   cmdItem->setToggledCB(FFaDynCB1S(FapMainWinCmds::showThreeDViewsToolBar,bool));
   cmdItem->setGetToggledCB(FFaDynCB1S(FapMainWinCmds::getThreeDViewsToolBarToggle,bool&));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_mainWin_showMechWindToolBar");
   cmdItem->setText("Windpower Creation");
   cmdItem->setToolTip("Windpower Creation");
   cmdItem->setToggledCB(FFaDynCB1S(FapMainWinCmds::showMechWindToolBar,bool));
   cmdItem->setGetToggledCB(FFaDynCB1S(FapMainWinCmds::getMechWindToolBarToggle,bool&));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_mainWin_showMechCreateToolBar");
   cmdItem->setText("Mechanism Creation");
   cmdItem->setToolTip("Mechanism Creation");
   cmdItem->setToggledCB(FFaDynCB1S(FapMainWinCmds::showMechCreateToolBar,bool));
   cmdItem->setGetToggledCB(FFaDynCB1S(FapMainWinCmds::getMechCreateToolBarToggle,bool&));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_mainWin_showMechModellingToolsToolBar");
   cmdItem->setText("Mechanism Modelling Tools");
   cmdItem->setToolTip("Mechanism Modelling Tools");
   cmdItem->setToggledCB(FFaDynCB1S(FapMainWinCmds::showMechModellingToolsToolBar,bool));
   cmdItem->setGetToggledCB(FFaDynCB1S(FapMainWinCmds::getMechModellingToolsToolBarToggle,bool&));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_mainWin_showCtrlCreateToolBar");
   cmdItem->setText("Control System Create");
   cmdItem->setToolTip("Control System Create Toolbar");
   cmdItem->setToggledCB(FFaDynCB1S(FapMainWinCmds::showCtrlCreateToolBar,bool));
   cmdItem->setGetToggledCB(FFaDynCB1S(FapMainWinCmds::getCtrlCreateToolBarToggle,bool&));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_mainWin_showCtrlModellingToolsToolBar");
   cmdItem->setText("Control System Modelling Tools");
   cmdItem->setToolTip("Control System Modelling Tools Toolbar");
   cmdItem->setToggledCB(FFaDynCB1S(FapMainWinCmds::showCtrlModellingToolsToolBar,bool));
   cmdItem->setGetToggledCB(FFaDynCB1S(FapMainWinCmds::getCtrlModellingToolsToolBarToggle,bool&));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 }
 //----------------------------------------------------------------------------
 

--- a/src/vpmApp/vpmAppCmds/FapMech3DObjCmds.C
+++ b/src/vpmApp/vpmAppCmds/FapMech3DObjCmds.C
@@ -210,7 +210,6 @@ void FapMech3DObjCmds::init()
   cmdItem->setText("Item Appearance...");
   cmdItem->setToolTip("Item Appearance");
   cmdItem->setActivatedCB(FFaDynCB0S([](){ FuiModes::setMode(FuiModes::APPEARANCE_MODE); }));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 }
 //----------------------------------------------------------------------------
 

--- a/src/vpmApp/vpmAppCmds/FapSolveCmds.C
+++ b/src/vpmApp/vpmAppCmds/FapSolveCmds.C
@@ -75,7 +75,7 @@ char FapSolveCmds::haveCloudAccess = 0;
 
 void FapSolveCmds::init()
 {
-  //! Lambda function for sensitivity on part-level recovery commands
+  // Lambda function for sensitivity on part-level recovery commands
   auto&& getSolveOnPartSensitivity = [](bool& sensitive)
   {
     if (FpPM::isModelTouchable())
@@ -90,7 +90,7 @@ void FapSolveCmds::init()
       sensitive = false;
   };
 
-  //! Lambda function for sensitivity on element group-level recovery commands
+  // Lambda function for sensitivity on element group-level recovery commands
   auto&& getSolveOnPartGroupSensitivity = [](bool& sensitive)
   {
     if (FpPM::isModelTouchable())
@@ -101,6 +101,41 @@ void FapSolveCmds::init()
         if (!(sensitive = (sel->isOfType(FmPart::getClassTypeID()) ||
                            sel->isOfType(FmElementGroupProxy::getClassTypeID()))))
           break;
+    }
+    else
+      sensitive = false;
+  };
+
+  // Lambda function for sensitivity on part-level mode shape recovery
+  auto&& getSolveModesOnPartSensitivity = [](bool& sensitive)
+  {
+    sensitive = false;
+    if (FpPM::isModelTouchable() && FmDB::getModesOptions(false))
+      if (FmAnalysis* ana = FmDB::getActiveAnalysis(false);
+	  ana && ana->solveEigenvalues.getValue())
+      {
+        std::vector<FmModelMemberBase*> selection;
+        sensitive = FapCmdsBase::getCurrentSelection(selection);
+        for (FmModelMemberBase* sel : selection)
+          if (!(sensitive = sel->isOfType(FmPart::getClassTypeID())))
+            break;
+      }
+  };
+
+  // Lambda function for sensitivity on part-level gage recovery
+  auto&& getSolveGageOnPartSensitivity = [](bool& sensitive)
+  {
+    if (FpPM::isModelTouchable())
+    {
+      bool selectionHasRosettes = false;
+      std::vector<FmModelMemberBase*> selection;
+      sensitive = FapCmdsBase::getCurrentSelection(selection);
+      for (FmModelMemberBase* sel : selection)
+        if (!(sensitive = sel->isOfType(FmPart::getClassTypeID())))
+          break;
+        else if (static_cast<FmPart*>(sel)->hasStrainRosettes())
+          selectionHasRosettes = true;
+      sensitive &= selectionHasRosettes;
     }
     else
       sensitive = false;
@@ -199,12 +234,19 @@ void FapSolveCmds::init()
   cmdItem->setActivatedCB(FFaDynCB0S(FapSolveCmds::solveStressOnPart));
   cmdItem->setGetSensitivityCB(FFaDynCB1S(getSolveOnPartGroupSensitivity,bool&));
 
+  cmdItem = new FFuaCmdItem("cmdId_solve_solveModesOnLink");
+  cmdItem->setSmallIcon(solveModes_xpm);
+  cmdItem->setText("Mode Shapes");
+  cmdItem->setToolTip("Recover Mode Shapes on FE part");
+  cmdItem->setActivatedCB(FFaDynCB0S([](){ FapSolveCmds::solveModes(false,true); }));
+  cmdItem->setGetSensitivityCB(FFaDynCB1S(getSolveModesOnPartSensitivity,bool&));
+
   cmdItem = new FFuaCmdItem("cmdId_solve_solveRosetteOnLink");
   cmdItem->setSmallIcon(solveRosette_xpm);
   cmdItem->setText("Strain Rosettes");
   cmdItem->setToolTip("Recover Strain Rosettes on FE part");
   cmdItem->setActivatedCB(FFaDynCB0S(FapSolveCmds::solveRosetteOnPart));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(getSolveOnPartSensitivity,bool&));
+  cmdItem->setGetSensitivityCB(FFaDynCB1S(getSolveGageOnPartSensitivity,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_solve_solveStrainCoatOnLink");
   cmdItem->setSmallIcon(solveStrainCoat_xpm);
@@ -696,7 +738,7 @@ bool FapSolveCmds::solveStress(bool prepareForBatchOnly)
 
 //----------------------------------------------------------------------------
 
-bool FapSolveCmds::solveModes(bool prepareForBatchOnly)
+bool FapSolveCmds::solveModes(bool prepareForBatchOnly, bool forSelected)
 {
   FmSimulationEvent* event = FapSimEventHandler::getActiveEvent();
   if (event && !FapLicenseManager::checkSimEventLicense())
@@ -709,7 +751,10 @@ bool FapSolveCmds::solveModes(bool prepareForBatchOnly)
   std::string vtfFile;
 
   std::vector<FmPart*> allParts;
-  FmDB::getFEParts(allParts,true);
+  if (forSelected)
+    FapCmdsBase::getSelectedParts(allParts);
+  else
+    FmDB::getFEParts(allParts,true);
 
   for (FmPart* part : allParts)
   {

--- a/src/vpmApp/vpmAppCmds/FapSolveCmds.H
+++ b/src/vpmApp/vpmAppCmds/FapSolveCmds.H
@@ -33,7 +33,7 @@ public:
 
   static bool solveAll(bool preBatch);
   static bool solveStress(bool preBatch);
-  static bool solveModes(bool preBatch);
+  static bool solveModes(bool preBatch, bool forSelected = false);
   static bool solveRosette(bool preBatch);
   static bool solveStrainCoat(bool preBatch);
 

--- a/src/vpmApp/vpmAppCmds/FapToolsCmds.C
+++ b/src/vpmApp/vpmAppCmds/FapToolsCmds.C
@@ -49,7 +49,6 @@ void FapToolsCmds::init()
   cmdItem->setText("Show Modeler");
   cmdItem->setToolTip("Show Modeler");
   cmdItem->setActivatedCB(LAMBDA(Fui::modellerUI();FuiModes::cancel()));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_ctrl_show");
   cmdItem->setSmallIcon(ctrlSystem_xpm);
@@ -58,49 +57,42 @@ void FapToolsCmds::init()
 #ifdef USE_INVENTOR
   cmdItem->setActivatedCB(LAMBDA_CTRL(FdCtrlDB::openCtrl()));
 #endif
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_ctrl_gridSnap");
   cmdItem->setSmallIcon(ctrlGrid_xpm);
   cmdItem->setText("Control Editor Grid/Snap...");
   cmdItem->setToolTip("Control Editor Grid/Snap");
   cmdItem->setActivatedCB(LAMBDA_CTRL(Fui::ctrlGridSnapUI()));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_tools_preferences");
   cmdItem->setSmallIcon(additionalSolverOptions_xpm);
   cmdItem->setText("Additional Solver Options...");
   cmdItem->setToolTip("Additional Solver Options");
   cmdItem->setActivatedCB(LAMBDA(Fui::preferencesUI()));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_tools_viewFilter");
   cmdItem->setSmallIcon(viewFilter_xpm);
   cmdItem->setText("General Appearance...");
   cmdItem->setToolTip("General Appearance");
   cmdItem->setActivatedCB(LAMBDA(Fui::viewSettingsUI()));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_tools_objectBrowser");
   cmdItem->setSmallIcon(objectBrowser_xpm);
   cmdItem->setText("Object Browser...");
   cmdItem->setToolTip("Object Browser");
   cmdItem->setActivatedCB(LAMBDA(Fui::objectBrowserUI()));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_tools_outputList");
   cmdItem->setSmallIcon(infoList_xpm);
   cmdItem->setText("Show Output List");
   cmdItem->setToolTip("Show Output List");
   cmdItem->setActivatedCB(LAMBDA(Fui::outputListUI()));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_tools_miniFileBrowser");
   cmdItem->setSmallIcon(browseRDB_xpm);
   cmdItem->setText("Result File Browser...");
   cmdItem->setToolTip("Result File Browser");
   cmdItem->setActivatedCB(LAMBDA(Fui::resultFileBrowserUI()));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_tools_linkRamSettings");
   cmdItem->setSmallIcon(linkRamSettings_xpm);
@@ -113,42 +105,36 @@ void FapToolsCmds::init()
   cmdItem->setText("Model Preferences...");
   cmdItem->setToolTip("Model Preferences");
   cmdItem->setActivatedCB(LAMBDA(Fui::modelPreferencesUI()));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_tools_seaEnvironment");
   cmdItem->setSmallIcon(sea_xpm);
   cmdItem->setText("Sea Environment...");
   cmdItem->setToolTip("Sea Environment");
   cmdItem->setActivatedCB(LAMBDA(Fui::seaEnvironmentUI()));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_tools_airEnvironment");
   cmdItem->setSmallIcon(windAirEnv_xpm);
   cmdItem->setText("Aerodynamic Setup...");
   cmdItem->setToolTip("Aerodynamic Setup");
   cmdItem->setActivatedCB(LAMBDA(Fui::airEnvironmentUI()));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_tools_airfoilDefinition");
   cmdItem->setSmallIcon(windAirFoil_xpm);
   cmdItem->setText("Browse Airfoils...");
   cmdItem->setToolTip("Browse Airfoils for Turbine Blades");
   cmdItem->setActivatedCB(LAMBDA(Fui::airfoilDefinitionUI()));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_tools_bladeDefinition");
   cmdItem->setSmallIcon(windBladeProp_xpm);
   cmdItem->setText("Blade Definition...");
   cmdItem->setToolTip("Blade definition for Turbine Assembly");
   cmdItem->setActivatedCB(LAMBDA(Fui::bladeDefinitionUI()));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_tools_createTurbineAssembly");
   cmdItem->setSmallIcon(windTurbine_xpm);
   cmdItem->setText("Turbine Definition...");
   cmdItem->setToolTip("Turbine Definition");
   cmdItem->setActivatedCB(LAMBDA(Fui::turbineAssemblyUI()));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_tools_createTurbineTower");
   cmdItem->setSmallIcon(windTower_xpm);
@@ -165,45 +151,38 @@ void FapToolsCmds::init()
   cmdItem->setText("Beamstring Pair Definition...");
   cmdItem->setToolTip("Beamstring Pair Definition");
   cmdItem->setActivatedCB(LAMBDA(Fui::beamstringPairUI()));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_tools_setFileAssociations");
   cmdItem->setText("Set File Associations...");
   cmdItem->setToolTip("Set File Associations");
   cmdItem->setActivatedCB(FFaDynCB0S(FapToolsCmds::setFileAssociations));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_tools_plugins");
   cmdItem->setText("Plug-Ins...");
   cmdItem->setToolTip("Plug-Ins");
   cmdItem->setActivatedCB(LAMBDA(Fui::pluginsUI()));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_tools_eventDefinition");
   cmdItem->setSmallIcon(eventDef_xpm);
   cmdItem->setText("Event Definitions...");
   cmdItem->setToolTip("Events");
   cmdItem->setActivatedCB(LAMBDA(Fui::eventDefinitionUI()));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_tools_distance");
   cmdItem->setSmallIcon(measureDistance_xpm);
   cmdItem->setText("Measure distance...");
   cmdItem->setToolTip("Measure distance between two points");
   cmdItem->setActivatedCB(LAMBDA(FuiModes::setMode(FuiModes::MEASURE_DISTANCE_MODE)));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_tools_angle");
   cmdItem->setSmallIcon(measureAngle_xpm);
   cmdItem->setText("Measure angle...");
   cmdItem->setToolTip("Measure angle between two points");
   cmdItem->setActivatedCB(LAMBDA(FuiModes::setMode(FuiModes::MEASURE_ANGLE_MODE)));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   for (int i = 0; i < 40; i++)
   {
     cmdItem = new FFuaCmdItem("cmdId_tools_addon" + std::to_string(i));
-    cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
     switch (i) {
     case  0: cmdItem->setActivatedCB(LAMBDA(FapToolsCmds::addonLaunch( 0))); break;
     case  1: cmdItem->setActivatedCB(LAMBDA(FapToolsCmds::addonLaunch( 1))); break;

--- a/src/vpmApp/vpmAppCmds/FapWorkSpaceCmds.C
+++ b/src/vpmApp/vpmAppCmds/FapWorkSpaceCmds.C
@@ -25,26 +25,22 @@ void FapWorkSpaceCmds::init()
   cmdItem->setText("Cascade");
   cmdItem->setToolTip("Cascade");
   cmdItem->setActivatedCB(FFaDynCB0S([](){ Fui::getMainWindow()->getWorkSpace()->cascadeWins(); }));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_workSpace_tile");
   cmdItem->setSmallIcon(tile_xpm);
   cmdItem->setText("Tile");
   cmdItem->setToolTip("Tile");
   cmdItem->setActivatedCB(FFaDynCB0S([](){ Fui::getMainWindow()->getWorkSpace()->tileWins(); }));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive,bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_workSpace_tabs");
   cmdItem->setSmallIcon(tabs_xpm);
   cmdItem->setText("Tabs");
   cmdItem->setToolTip("Tabs");
   cmdItem->setActivatedCB(FFaDynCB0S([](){ Fui::getMainWindow()->getWorkSpace()->tabWins(); }));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive, bool&));
 
   cmdItem = new FFuaCmdItem("cmdId_workSpace_subWins");
   cmdItem->setSmallIcon(tile_xpm);
   cmdItem->setText("Sub Windows");
   cmdItem->setToolTip("Sub Windows");
   cmdItem->setActivatedCB(FFaDynCB0S([](){ Fui::getMainWindow()->getWorkSpace()->subWins(); }));
-  cmdItem->setGetSensitivityCB(FFaDynCB1S(FapCmdsBase::alwaysSensitive, bool&));
 }

--- a/src/vpmApp/vpmAppDisplay/FapAnimationCreator.C
+++ b/src/vpmApp/vpmAppDisplay/FapAnimationCreator.C
@@ -52,7 +52,11 @@
 namespace FapMemoryProfiler { bool usage(const char* task); }
 #endif
 
-#include <functional>
+#ifdef USE_INVENTOR
+namespace
+{
+  FdPart* getFd(FmPart* part) { return static_cast<FdPart*>(part->getFdPointer()); }
+}
 
 
 /*!
@@ -114,6 +118,7 @@ private:
 #ifdef FT_USE_MEMPOOL
 FFaMemPool FapEccTransform::ourMemPool = FFaMemPool(sizeof(FapEccTransform),
                                                     FFaOperationBase::getMemPoolMgr());
+#endif
 #endif
 
 
@@ -219,7 +224,8 @@ bool FapAnimationCreator::initReading(FmAnimation* animation)
 
   // Get all links that may have results, optionally skip all blade elements
   bool skipBlades = animation->getUserDescription().find("#skipBlade") != std::string::npos;
-  std::function<bool(FmLink*)> filterBlade = [skipBlades](FmLink* link) -> bool
+  // Lambda function checking if a link is result-less.
+  auto&& filterBlade = [skipBlades](FmLink* link)
   {
     if (link->isSuppressed())
       return true;
@@ -317,11 +323,9 @@ double FapAnimationCreator::initRDB(DoubleSet& timeSteps,
   // Check whether to stop reading at last solved timestep
   if (IAmSummaryAnimation)
     myStopTime = *(timeSteps.rbegin()); // always use whole time domain
-  else {
-    double newDataEndTime = myExtractor->getLastWrittenTime();
-    if (newDataEndTime < myStopTime && newDataEndTime != -HUGE_VAL)
-      myStopTime = newDataEndTime;
-  }
+  else if (double newEndTime = myExtractor->getLastWrittenTime();
+           newEndTime < myStopTime && newEndTime != -HUGE_VAL)
+    myStopTime = newEndTime;
 #ifdef FAP_DEBUG
   std::cout <<"\tUsing time window ["<< gottenTime <<","<< myStopTime <<"]"<< std::endl;
 #endif
@@ -888,7 +892,7 @@ void FapAnimationCreator::initDeformationReading(FmPart* part, FFrExtractor* ext
   feRes->deformationOps.resize(feData->getVertexCount(),(FFaOperation<FaVec3>*)NULL);
 
 #ifdef USE_INVENTOR
-  FdPart* fdpart = static_cast<FdPart*>(part->getFdPointer());
+  FdPart* fdpart = getFd(part);
   if (fdpart->updateSpecialLines(-1.0))
     fdpart->updateFdDetails(); // Hide local beam system marker during animation
 #endif
@@ -965,7 +969,7 @@ void FapAnimationCreator::initDeformationReading(FmPart* part, FFrExtractor* ext
 void FapAnimationCreator::readDeformations(int frameIdx, FmPart* part)
 {
 #ifdef USE_INVENTOR
-  FdFEModel* visMod = static_cast<FdLink*>(part->getFdPointer())->getVisualModel();
+  FdFEModel* visMod = getFd(part)->getVisualModel();
   if (!visMod) return;
 
   if (visMod->hasResultDeformation(frameIdx)) return;
@@ -1018,9 +1022,8 @@ bool FapAnimationCreator::readDeformations(FaVec3Vec& def, FmPart* part)
   FFlrFELinkResult* linkRes = lh->getResults();
   def.reserve(lh->getNodeCount(FFlLinkHandler::FFL_FEM));
 
-  FFaOperation<FaVec3>* readOp = NULL;
   for (NodesCIter nit = lh->nodesBegin(); nit != lh->nodesEnd(); ++nit)
-    if ((readOp = linkRes->deformationOps[(*nit)->getVertexID()]))
+    if (FFaOperation<FaVec3>* readOp = linkRes->deformationOps[(*nit)->getVertexID()]; readOp)
     {
       FaVec3 dval;
       if (readOp->hasData())
@@ -1061,7 +1064,9 @@ void FapAnimationCreator::finishDeformationReading(FmPart* part)
 //
 //////////////////////////////////
 
-typedef FFlGroupPartCreator::GroupPartMap::value_type FFlGroupPartItem;
+#ifdef USE_INVENTOR
+using FFlGroupPartItem = FFlGroupPartCreator::GroupPartMap::value_type;
+#endif
 
 /*!
   Initializes operations etc for an FE part, filling its group part data objects
@@ -1158,17 +1163,17 @@ int FapAnimationCreator::initFringeReading(FmPart* part,
   else
   {
 #ifdef USE_INVENTOR
-    FdPart* fdpart = static_cast<FdPart*>(part->getFdPointer());
-    if (IAmLoadingFringeData%2)
-      for (const FFlGroupPartItem& it : fdpart->getGroupPartCreator()->getLinkParts())
+    FFlGroupPartCreator* gpc = getFd(part)->getGroupPartCreator();
+    if (IAmLoadingFringeData%2 && gpc)
+      for (FFlGroupPartItem& it : *gpc)
         if (it.first == FFlGroupPartCreator::SURFACE_FACES)
-          nOperations += FFlrFringeCreator::buildColorXfs(*(it.second),lh,fringeSetup);
+          nOperations += FFlrFringeCreator::buildColorXfs(it.second,lh,fringeSetup);
 
-    if (IAmLoadingFringeData/2)
-      for (const FFlGroupPartItem& it : fdpart->getGroupPartCreator()->getLinkParts())
+    if (IAmLoadingFringeData/2 && gpc)
+      for (FFlGroupPartItem& it : *gpc)
         if (it.first == FFlGroupPartCreator::OUTLINE_LINES ||
             it.first == FFlGroupPartCreator::SURFACE_LINES)
-          nOperations += FFlrFringeCreator::buildColorXfs(*(it.second),lh,fringeSetup);
+          nOperations += FFlrFringeCreator::buildColorXfs(it.second,lh,fringeSetup);
 #endif
   }
 #ifdef FAP_DEBUG
@@ -1213,30 +1218,24 @@ int FapAnimationCreator::initFringeReading(FmPart* part,
 
 
 void FapAnimationCreator::readFringeData(int frameIdx, FmPart* part,
-                                         const FFaLegendMapper&
-#ifdef USE_INVENTOR
-                                         legendMapping
-#endif
-                                         )
+                                         const FFaLegendMapper& legendMapping)
 {
 #ifdef USE_INVENTOR
+  FFlGroupPartCreator* gpc = getFd(part)->getGroupPartCreator();
+  if (!gpc) return;
+
 #ifdef FT_USE_PROFILER
   myProfiler->startTimer("Fringe Read");
 #endif
 
-  FdFEGroupPart::lookPolicy look = IHaveOneColorPrFace ? FdFEGroupPart::PR_FACE : FdFEGroupPart::PR_FACE_VERTEX;
-
   // Lambda function for assigning color fringe values to an FE group part.
-  auto&& setResult = [this,look,&legendMapping](FFlGroupPartData* gpd, int fidx)
+  auto&& setResult = [this,&legendMapping](const FFlGroupPartData& gpd, int fidx)
   {
-    if (!gpd->visualModel)
-      return;
-
-    if (gpd->visualModel->hasResultLook(fidx))
+    if (!gpd.visualModel || gpd.visualModel->hasResultLook(fidx))
       return;
 
     DoubleVec colors;
-    if (!FFlrFringeCreator::getColorData(colors,*gpd,IHaveOneColorPrFace))
+    if (!FFlrFringeCreator::getColorData(colors,gpd,IHaveOneColorPrFace))
       return;
 
     for (double& color : colors)
@@ -1249,17 +1248,18 @@ void FapAnimationCreator::readFringeData(int frameIdx, FmPart* part,
         if (color < myMinFringeValue) myMinFringeValue = color;
       }
 
-    gpd->visualModel->setResultLook(fidx,look,colors,legendMapping);
+    gpd.visualModel->setResultLook(fidx,
+                                   IHaveOneColorPrFace ? FdFEGroupPart::PR_FACE : FdFEGroupPart::PR_FACE_VERTEX,
+                                   colors, legendMapping);
   };
 
-  FdPart* fdpart = static_cast<FdPart*>(part->getFdPointer());
   if (IAmLoadingFringeData%2)
-    for (const FFlGroupPartItem& it : fdpart->getGroupPartCreator()->getLinkParts())
+    for (const FFlGroupPartItem& it : *gpc)
       if (it.first == FFlGroupPartCreator::SURFACE_FACES)
         setResult(it.second,frameIdx);
 
   if (IAmLoadingFringeData/2)
-    for (const FFlGroupPartItem& it : fdpart->getGroupPartCreator()->getLinkParts())
+    for (const FFlGroupPartItem& it : *gpc)
       if (it.first == FFlGroupPartCreator::OUTLINE_LINES ||
           it.first == FFlGroupPartCreator::SURFACE_LINES)
         setResult(it.second,frameIdx);
@@ -1268,8 +1268,8 @@ void FapAnimationCreator::readFringeData(int frameIdx, FmPart* part,
   myProfiler->stopTimer("Fringe Read");
 #endif
 #else
-  std::cout <<"FapAnimationCreator::readFringeData("
-            << frameIdx <<","<< part->getBaseID()
+  std::cout <<"FapAnimationCreator::readFringeData("<< frameIdx
+            <<","<< part->getBaseID() <<","<< legendMapping.getMax()
             <<") does nothing."<< std::endl;
 #endif
 }
@@ -1287,9 +1287,8 @@ bool FapAnimationCreator::readFringeData(DoubleVec& values, FmPart* part)
   size_t nRes = linkRes->scalarOps.size();
 
   for (size_t i = 0; i < nRes; i++)
-  {
-    FFaOperation<double>* readOp = linkRes->scalarOps[i];
-    if (readOp && readOp->hasData())
+    if (FFaOperation<double>* readOp = linkRes->scalarOps[i];
+        readOp && readOp->hasData())
     {
       if (values.empty())
         values.resize(nRes,HUGE_VAL);
@@ -1297,7 +1296,6 @@ bool FapAnimationCreator::readFringeData(DoubleVec& values, FmPart* part)
       if (fabs(values[i] - mySpecialValue) < mySpecialValue/1.0e7)
 	values[i] = mySpValConvertValue;
     }
-  }
 
 #ifdef FT_USE_PROFILER
   myProfiler->stopTimer("Fringe Read");
@@ -1326,9 +1324,8 @@ bool FapAnimationCreator::readFringeData(std::vector<DoubleVec>& values, FmPart*
     int n = linkRes->elmStart[i+1] - k;
     values[i].resize(n);
     for (int j = 0; j < n; j++)
-    {
-      FFaOperation<double>* readOp = linkRes->scalarOps[k+j];
-      if (readOp && readOp->hasData())
+      if (FFaOperation<double>* readOp = linkRes->scalarOps[k+j];
+          readOp && readOp->hasData())
       {
 	gotData = true;
 	readOp->evaluate(values[i][j]);
@@ -1337,7 +1334,6 @@ bool FapAnimationCreator::readFringeData(std::vector<DoubleVec>& values, FmPart*
       }
       else
 	values[i][j] = HUGE_VAL;
-    }
   }
 
 #ifdef FT_USE_PROFILER
@@ -1364,17 +1360,17 @@ void FapAnimationCreator::finishFringeReading(FmPart* part)
   // Delete temporary data on the faces and edges
 
 #ifdef USE_INVENTOR
-  FdPart* fdpart = static_cast<FdPart*>(part->getFdPointer());
+  FFlGroupPartCreator* gpc = getFd(part)->getGroupPartCreator();
   if (IAmLoadingFringeData%2)
-    for (const FFlGroupPartItem& it : fdpart->getGroupPartCreator()->getLinkParts())
+    for (FFlGroupPartItem& it : *gpc)
       if (it.first == FFlGroupPartCreator::SURFACE_FACES)
-        FFlrFringeCreator::deleteColorsXfs(*it.second,memPoll);
+        FFlrFringeCreator::deleteColorsXfs(it.second,memPoll);
 
   if (IAmLoadingFringeData/2)
-    for (const FFlGroupPartItem& it : fdpart->getGroupPartCreator()->getLinkParts())
+    for (FFlGroupPartItem& it : *gpc)
       if (it.first == FFlGroupPartCreator::OUTLINE_LINES ||
           it.first == FFlGroupPartCreator::SURFACE_LINES)
-        FFlrFringeCreator::deleteColorsXfs(*it.second,memPoll);
+        FFlrFringeCreator::deleteColorsXfs(it.second,memPoll);
 #endif
 
 #ifdef FT_USE_PROFILER
@@ -1678,11 +1674,9 @@ bool FapAnimationCreator::exportToVTF(FmAnimation* animation,
     // Read and write FE part deformations
     if (IAmLoadingDeformData)
       for (i = 0; i < myParts.size() && status; i++)
-      {
-        FaVec3Vec dis;
-        if (FapAnimationCreator::readDeformations(dis,myParts[i]))
+        if (FaVec3Vec dis;
+            FapAnimationCreator::readDeformations(dis,myParts[i]))
           status = vtf.writeDeformations(myParts[i]->getBaseID(),dis);
-      }
 
     // Read and write fringe results
     if (IAmLoadingFringeData%2)
@@ -1691,16 +1685,16 @@ bool FapAnimationCreator::exportToVTF(FmAnimation* animation,
         if (iResMap == 2)
         {
           // Element-nodal results
-          std::vector<DoubleVec> values;
-          if (FapAnimationCreator::readFringeData(values,myParts[i]))
+          if (std::vector<DoubleVec> values;
+              FapAnimationCreator::readFringeData(values,myParts[i]))
             status = vtf.writeFringes(myParts[i]->getBaseID(),values,
                                       animation->getFringeQuantity());
         }
         else
         {
           // Element or nodal results
-          DoubleVec values;
-          if (FapAnimationCreator::readFringeData(values,myParts[i]))
+          if (DoubleVec values;
+              FapAnimationCreator::readFringeData(values,myParts[i]))
             status = vtf.writeFringes(myParts[i]->getBaseID(),values,
                                       animation->getFringeQuantity(),
                                       iResMap == 1);

--- a/src/vpmApp/vpmAppDisplay/FapGraphDataMap.C
+++ b/src/vpmApp/vpmAppDisplay/FapGraphDataMap.C
@@ -24,7 +24,7 @@
 
 
 /*!
-  Builds the \a dataMap with operations and then reads data from the RDB,
+  Builds the \ref dataMap with operations and then reads data from the RDB,
   external curve data files, and/or internal functions for a set of \a curves.
   Error messages (if any) are given in a dialog box and output list if the
   the pointer \a errMsg is null. Otherwise, they are returned in \a *errMsg.
@@ -36,14 +36,21 @@ bool FapGraphDataMap::findPlottingData(const std::vector<FmCurveSet*>& curves,
   if (curves.empty())
     return true;
 
+#ifdef FAP_DEBUG
+  std::cout <<"\nFapGraphDataMap::findPlottingData():";
+  for (FmCurveSet* curve : curves)
+    std::cout <<"\n\t"<< curve->getIdString(true);
+  std::cout << std::endl;
+#endif
+
   // First, resolve the combined curves (if any) such that we
   // only try to read the basic curves (RDB, external and function)
-  std::vector<FmCurveSet*> bCurves(curves);
-  replaceCombinedCurves(bCurves);
+  std::vector<FmCurveSet*> bCurves(curves), cCurves;
+  resolveCombinedCurves(bCurves,cCurves);
 #ifdef FAP_DEBUG
-  if (bCurves != curves)
-    std::cout <<"FapGraphDataMap: Resolved combined curves "
-              << curves.size() <<" --> "<< bCurves.size() << std::endl;
+  if (bCurves.size() < curves.size())
+    std::cout <<"FapGraphDataMap: Resolved combined curves "<< curves.size()
+              <<" --> "<< bCurves.size() <<"+"<< cCurves.size() << std::endl;
 #endif
 
   std::string  msg1, msg2;
@@ -54,21 +61,26 @@ bool FapGraphDataMap::findPlottingData(const std::vector<FmCurveSet*>& curves,
 
   // Set the load time interval from the owner graph of the first RDB curve
   for (FmCurveSet* curve : curves)
-    if (curve->usingInputMode() == FmCurveSet::TEMPORAL_RESULT ||
-        curve->usingInputMode() == FmCurveSet::COMB_CURVES)
-      if (FmGraph* graph = curve->getOwnerGraph();
-          graph && graph->getUseTimeRange())
-      {
-	double tmin, tmax;
-	graph->getTimeRange(tmin,tmax);
-	rdbCurves.setTimeInterval(tmin,tmax);
-	break;
-      }
+    if (FmGraph* graph = curve->getOwnerGraph();
+        graph && graph->getUseTimeRange() && curve->isResultDependent())
+    {
+      double tmin, tmax;
+      graph->getTimeRange(tmin,tmax);
+      rdbCurves.setTimeInterval(tmin,tmax);
+#ifdef FAP_DEBUG
+      std::cout <<"\tUsing time range ["<< tmin <<","<< tmax <<"]"<< std::endl;
+#endif
+      break;
+    }
 
+  // Loop over all curves that should be loaded, to initialize for RBD reading,
+  // and to load the data for curves of type function and external
   int rdbType = -1;
-  std::map<const FmCurveSet*,FFpCurve>::iterator cit;
-  for (FmCurveSet* curve : bCurves)
+  const size_t nBC = bCurves.size();
+  for (size_t j = 0; j < nBC+cCurves.size(); j++)
   {
+    FmCurveSet* curve = j < nBC ? bCurves[j] : cCurves[j-nBC];
+
     if (curve->usingInputMode() == FmCurveSet::SPATIAL_RESULT)
     {
       std::vector<FmIsPlottedBase*> spatialObjs;
@@ -125,7 +137,7 @@ bool FapGraphDataMap::findPlottingData(const std::vector<FmCurveSet*>& curves,
 
 	// Initialize the axis definitions for this spatial RDB-curve.
 	// Any existing curve data is thrown away.
-	FFpCurve& ffpc = dataMap[curve];
+	FFpCurve& ffpc = j < nBC ? dataMap[curve] : compMap[curve];
 	ffpc.resize(nPoints);
 	ffpc.initAxes(xDescr,spatialDescr,
 		      curve->getResultOper(FmCurveSet::XAXIS),
@@ -135,8 +147,11 @@ bool FapGraphDataMap::findPlottingData(const std::vector<FmCurveSet*>& curves,
       }
     }
 
-    if ((cit = dataMap.find(curve)) == dataMap.end())
+    FapDataMap::iterator cit;
+    if (j < nBC && (cit = dataMap.find(curve)) == dataMap.end())
       cit = dataMap.emplace(curve,FFpCurve()).first; // new RDB-curve
+    else if (j >= nBC && (cit = compMap.find(curve)) == compMap.end())
+      cit = compMap.emplace(curve,FFpCurve()).first; // new RDB-curve
     else if (cit->first->usingInputMode() == FmCurveSet::TEMPORAL_RESULT)
     {
       // Clear the temporal RDB-curve data when ...
@@ -147,6 +162,11 @@ bool FapGraphDataMap::findPlottingData(const std::vector<FmCurveSet*>& curves,
       else if (cit->first->hasDFTOptionsChanged(1))
         // DFT-options have changed while DFT is on, or we are appending
         cit->second.clear(); // while the DFT was switched off
+#ifdef FAP_DEBUG
+      else
+        std::cout <<"\tRetain cached curve data for "
+                  << cit->first->getIdString() << std::endl;
+#endif
     }
 
     if (cit->first->usingInputMode() <= FmCurveSet::RDB_RESULT)
@@ -175,22 +195,22 @@ bool FapGraphDataMap::findPlottingData(const std::vector<FmCurveSet*>& curves,
       break;
 
     case FmCurveSet::EXT_CURVE:
-      // Find data for "external curves" (i.e. defined via ascii/dac/rpc file)
+      // Find data for "external curves" (i.e., defined via ascii/dac/rpc file)
       if (cit->first->hasXYDataChanged() ||      // the curve data has changed
-	  cit->first->hasDFTOptionsChanged(1) || // options for dft has changed
-	  cit->second.empty())                   // this is the first read
-	if (!findDataFromFile(cit->first, cit->second, listMsg))
-	  cit->second.clear();
+          cit->first->hasDFTOptionsChanged(1) || // options for dft has changed
+          cit->second.empty())                   // this is the first read
+        if (!findDataFromFile(cit->first, cit->second, listMsg))
+          cit->second.clear();
       break;
 
     case FmCurveSet::INT_FUNCTION:
     case FmCurveSet::PREVIEW_FUNC:
       // Find data for "internal function" curves
       if (cit->first->hasXYDataChanged() ||      // the curve data has changed
-	  cit->first->hasDFTOptionsChanged(1) || // options for dft has changed
-	  cit->second.empty())                   // this is the first read
-	if (!findDataFromFunc(cit->first, cit->second, listMsg))
-	  cit->second.clear();
+          cit->first->hasDFTOptionsChanged(1) || // options for dft has changed
+          cit->second.empty())                   // this is the first read
+        if (!findDataFromFunc(cit->first, cit->second, listMsg))
+          cit->second.clear();
       break;
 
     default:
@@ -216,6 +236,78 @@ bool FapGraphDataMap::findPlottingData(const std::vector<FmCurveSet*>& curves,
           xValue = p->getGlobalCS().translation()[ix];
   };
 
+  // Lambda function transforming the curve data based on the user settings.
+  auto&& transformData = [isAppending,&message](const FmCurveSet* curve,
+                                                FFpCurve& crvData)
+  {
+    bool transformed = !isAppending;
+    if (curve->derivate())
+    {
+      if (!isAppending)
+        FFaMsg::pushStatus("Differentiating");
+#ifdef FAP_DEBUG
+      std::cout <<"FapGraphDataMap: Differentiating "
+                << curve->getIdString(true) << std::endl;
+#endif
+      if (!crvData.replaceByScaledShifted(curve->getDFTparameters()))
+        crvData.clear();
+      else if (!crvData.replaceByDerivative())
+        crvData.clear();
+    }
+    else if (curve->integrate())
+    {
+      if (!isAppending)
+        FFaMsg::pushStatus("Integrating");
+#ifdef FAP_DEBUG
+      std::cout <<"FapGraphDataMap: Integrating "
+                << curve->getIdString(true) << std::endl;
+#endif
+      if (!crvData.replaceByScaledShifted(curve->getDFTparameters()))
+        crvData.clear();
+      else if (!crvData.replaceByIntegral())
+        crvData.clear();
+    }
+    else if (curve->doDft())
+    {
+      if (!isAppending)
+        FFaMsg::pushStatus("Doing DFT transformation");
+#ifdef FAP_DEBUG
+      std::cout <<"FapGraphDataMap: DFT transforming "
+                << curve->getIdString(true) << std::endl;
+#endif
+      if (!crvData.replaceByDFT(curve->getDFTparameters(),
+                                curve->getUserDescription(),message))
+        crvData.clear(); // Don't plot curve if the DFT failed
+    }
+    else if (curve->doRainflow())
+    {
+      if (!isAppending)
+        FFaMsg::pushStatus("Doing rainflow analysis");
+#ifdef FAP_DEBUG
+      std::cout <<"FapGraphDataMap: Rainflow transforming "
+                << curve->getIdString(true) << std::endl;
+#endif
+      double ys = curve->getYScale();
+      RFprm rf(curve->getFatigueGateValue()/ys);
+      if (!curve->getFatigueEntireDomain())
+      {
+        rf.start = curve->getFatigueDomain().first;
+        rf.stop  = curve->getFatigueDomain().second;
+      }
+
+      // Beta feature: Plotting the peak-and-valley extraction results
+      bool pvx = curve->getUserDescription().find("#PVX") < std::string::npos;
+      if (!crvData.replaceByRainflow(rf,ys,pvx,curve->getUserDescription(),
+                                     message))
+        crvData.clear(); // Don't plot curve if the Rainflow failed
+    }
+    else
+      transformed = false;
+
+    if (transformed)
+      FFaMsg::popStatus();
+  };
+
   if (!rdbCurves.empty())
   {
     // Actually read the RDB curves from file
@@ -231,9 +323,9 @@ bool FapGraphDataMap::findPlottingData(const std::vector<FmCurveSet*>& curves,
     {
       readOK = rdbCurves.loadSpatialData (extr,message);
       if (rdbCurves.getNoXaxisValues())
-        for (cit = dataMap.begin(); cit != dataMap.end(); ++cit)
-          if (cit->first->usingInputMode() == FmCurveSet::SPATIAL_RESULT)
-            setXvalue(cit->second,cit->first->getResultOper(FmCurveSet::XAXIS));
+        for (FapDataMap::value_type& cp : dataMap)
+          if (cp.first->usingInputMode() == FmCurveSet::SPATIAL_RESULT)
+            setXvalue(cp.second,cp.first->getResultOper(FmCurveSet::XAXIS));
     }
     if (!isAppending) FFaMsg::popStatus();
     if (readOK && !msg1.empty())
@@ -245,91 +337,25 @@ bool FapGraphDataMap::findPlottingData(const std::vector<FmCurveSet*>& curves,
     }
   }
 
+  // Replace curve components by their Derivative, Fourier transform, etc.
+  for (FapDataMap::value_type& cp : compMap)
+    if (cp.first->hasDFTOptionsChanged() || cp.second.hasDataChanged())
+    {
+      transformData(cp.first,cp.second);
+      cp.second.onDataPlotted(); // Fix issue #148: Reset the dataChanged flag
+      // after the data has been transformed, to avoid they are transformed
+      // again when the combined curve using this curve is reloaded.
+    }
+
   // Process the expressions of the combined curves, if any
   for (FmCurveSet* curve : curves)
     if (curve->usingInputMode() == FmCurveSet::COMB_CURVES)
       findCombinedCurveData(curve,listMsg);
 
   // Replace the wanted curves by their Derivative, Fourier transform, etc.
-  int giveStatus = isAppending ? 0 : 1;
-  for (cit = dataMap.begin(); cit != dataMap.end(); ++cit)
-    if (cit->first->hasDFTOptionsChanged() || cit->second.hasDataChanged())
-    {
-      if (cit->first->derivate())
-      {
-	if (giveStatus == 1)
-	{
-	  FFaMsg::pushStatus("Differentiating");
-	  giveStatus = 2;
-	}
-#ifdef FAP_DEBUG
-        std::cout <<"FapGraphDataMap: Differentiating "
-                  << cit->first->getIdString(true) << std::endl;
-#endif
-	if (!cit->second.replaceByScaledShifted(cit->first->getDFTparameters()))
-	  cit->second.clear();
-	else if (!cit->second.replaceByDerivative())
-	  cit->second.clear();
-      }
-      else if (cit->first->integrate())
-      {
-	if (giveStatus == 1)
-	{
-	  FFaMsg::pushStatus("Integrating");
-	  giveStatus = 2;
-	}
-#ifdef FAP_DEBUG
-        std::cout <<"FapGraphDataMap: Integrating "
-                  << cit->first->getIdString(true) << std::endl;
-#endif
-	if (!cit->second.replaceByScaledShifted(cit->first->getDFTparameters()))
-	  cit->second.clear();
-	else if (!cit->second.replaceByIntegral())
-	  cit->second.clear();
-      }
-      else if (cit->first->doDft())
-      {
-	if (giveStatus == 1)
-	{
-	  FFaMsg::pushStatus("Doing DFT transformation");
-	  giveStatus = 2;
-	}
-#ifdef FAP_DEBUG
-        std::cout <<"FapGraphDataMap: DFT transforming "
-                  << cit->first->getIdString(true) << std::endl;
-#endif
-	if (!cit->second.replaceByDFT(cit->first->getDFTparameters(),
-				      cit->first->getUserDescription(),message))
-	  cit->second.clear(); // Don't plot curve if the DFT failed
-      }
-      else if (cit->first->doRainflow())
-      {
-	if (giveStatus == 1)
-	{
-	  FFaMsg::pushStatus("Doing rainflow analysis");
-	  giveStatus = 2;
-	}
-#ifdef FAP_DEBUG
-        std::cout <<"FapGraphDataMap: Rainflow transforming "
-                  << cit->first->getIdString(true) << std::endl;
-#endif
-	double ys = cit->first->getYScale();
-	RFprm rf(cit->first->getFatigueGateValue()/ys);
-	if (!cit->first->getFatigueEntireDomain())
-	{
-	  rf.start = cit->first->getFatigueDomain().first;
-	  rf.stop = cit->first->getFatigueDomain().second;
-	}
-
-	// Beta feature: Plotting the peak-and-valley extraction results
-	bool pvx = cit->first->getUserDescription().find("#PVX") < std::string::npos;
-	if (!cit->second.replaceByRainflow(rf,ys,pvx,
-					   cit->first->getUserDescription(),
-					   message))
-	  cit->second.clear(); // Don't plot curve if the Rainflow failed
-      }
-    }
-  if (giveStatus == 2) FFaMsg::popStatus();
+  for (FapDataMap::value_type& cp : dataMap)
+    if (cp.first->hasDFTOptionsChanged() || cp.second.hasDataChanged())
+      transformData(cp.first,cp.second);
 
   if (errMsg) return errMsg->empty(); // Error messages are returned in *errMsg
 
@@ -361,23 +387,22 @@ bool FapGraphDataMap::findPlottingData(const std::vector<FmCurveSet*>& curves,
 
 
 /*!
-  Replaces the combined curves in a vector by their respective curve components.
+  Recursive method to find the basic curve components of the combined curves.
 */
 
-void FapGraphDataMap::replaceCombinedCurves(std::vector<FmCurveSet*>& curves)
+void FapGraphDataMap::resolveCombinedCurves(std::vector<FmCurveSet*>& curves,
+                                            std::vector<FmCurveSet*>& cCurves)
 {
-  std::vector<FmCurveSet*> eCurves;
   for (size_t j = 0; j < curves.size();)
     if (curves[j]->usingInputMode() == FmCurveSet::COMB_CURVES)
     {
       std::vector<FmCurveSet*> comps;
       curves[j]->getActiveCurveComps(comps);
+      resolveCombinedCurves(comps,cCurves);
       for (FmCurveSet* comp : comps)
-        if (std::find(curves.begin(),curves.end(),comp) == curves.end())
-          if (std::find(eCurves.begin(),eCurves.end(),comp) == eCurves.end())
-            curves.push_back(comp);
+        if (std::find(cCurves.begin(),cCurves.end(),comp) == cCurves.end())
+          cCurves.push_back(comp);
 
-      eCurves.push_back(curves[j]);
       curves.erase(curves.begin()+j);
     }
     else
@@ -401,7 +426,8 @@ bool FapGraphDataMap::findDataFromFunc(const FmCurveSet* curve,
 
 #ifdef FAP_DEBUG
   std::cout <<"FapGraphDataMap: Loading curve data from Function "
-            << function->getInfoString() << std::endl;
+            << function->getInfoString()
+            <<" for "<< curve->getIdString() << std::endl;
 #endif
 
   curveData.setDataChanged();
@@ -463,7 +489,7 @@ bool FapGraphDataMap::findDataFromFile(const FmCurveSet* curve,
 
 #ifdef FAP_DEBUG
   std::cout <<"FapGraphDataMap: Loading curve data from "<< filePath
-            << std::endl;
+            <<" for "<< curve->getIdString() << std::endl;
 #endif
   return curveData.loadFileData (filePath, curve->getChannelName(), message,
 				 timeRange.first, timeRange.second);
@@ -494,9 +520,7 @@ bool FapGraphDataMap::findCombinedCurveData(const FmCurveSet* ccrv,
   static std::vector<const FmCurveSet*> cStack;
   cStack.push_back(ccrv);
 
-  std::vector<FFpCurve>  transCrv;
   std::vector<FFpCurve*> comps(active.size(),NULL);
-  transCrv.reserve(active.size());
   for (size_t i = 0; i < active.size(); i++)
     if (active[i])
     {
@@ -510,22 +534,8 @@ bool FapGraphDataMap::findCombinedCurveData(const FmCurveSet* ccrv,
           + ": " + curves[i]->getIdString(true) + " is transformed.\n";
       else if (findCombinedCurveData(curves[i],message))
       {
-        if (curves[i]->derivate() || curves[i]->integrate() ||
-            curves[i]->hasNonDefaultScaleShift())
-        {
-          // Create a local copy of this curve component and transform it first
-          transCrv.push_back(dataMap[curves[i]]);
-          transCrv.back().replaceByScaledShifted(curves[i]->getDFTparameters());
-          bool transformed = true;
-          if (curves[i]->derivate())
-            transformed = transCrv.back().replaceByDerivative();
-          else if (curves[i]->integrate())
-            transformed = transCrv.back().replaceByIntegral();
-          if (transformed)
-            comps[i] = &transCrv.back();
-        }
-        else
-          comps[i] = this->getFFpCurve(curves[i],false);
+        FapDataMap::iterator cit = compMap.find(curves[i]);
+        if (cit != compMap.end()) comps[i] = &cit->second;
       }
     }
 
@@ -556,7 +566,7 @@ FFpCurve* FapGraphDataMap::getFFpCurve(const FmCurveSet* curve,
 {
   if (!curve) return NULL;
 
-  std::map<const FmCurveSet*,FFpCurve>::iterator cit = dataMap.find(curve);
+  FapDataMap::iterator cit = dataMap.find(curve);
   if (cit == dataMap.end())
     return createIfNone ? &dataMap[curve] : NULL;
 
@@ -579,8 +589,8 @@ FFpCurve* FapGraphDataMap::getFFpCurve(const FmCurveSet* curve,
 
 bool FapGraphDataMap::hasDataChanged(const FmCurveSet* curve) const
 {
-  std::map<const FmCurveSet*,FFpCurve>::const_iterator c = dataMap.find(curve);
-  return c == dataMap.end() ? true : c->second.hasDataChanged();
+  FapDataMap::const_iterator cit = dataMap.find(curve);
+  return cit == dataMap.end() ? true : cit->second.hasDataChanged();
 }
 
 
@@ -591,11 +601,11 @@ bool FapGraphDataMap::hasDataChanged(const FmCurveSet* curve) const
 
 bool FapGraphDataMap::setDataChanged(const FmCurveSet* curve)
 {
-  std::map<const FmCurveSet*,FFpCurve>::iterator c = dataMap.find(curve);
-  if (c == dataMap.end() || c->second.hasDataChanged())
+  FapDataMap::iterator cit = dataMap.find(curve);
+  if (cit == dataMap.end() || cit->second.hasDataChanged())
     return false;
 
-  c->second.setDataChanged();
+  cit->second.setDataChanged();
   return true;
 }
 
@@ -632,23 +642,22 @@ bool FapGraphDataMap::getCurveStatistics(std::vector<FapCurveSet>& stat,
 					 bool scaledShifted, bool wholeDomain,
 					 double startT, double stopT) const
 {
-  stat.resize(dataMap.size());
+  stat.clear();
+  stat.reserve(dataMap.size());
 
   std::string msg;
-  std::vector<FapCurveSet>::iterator sit = stat.begin();
-  std::map<const FmCurveSet*,FFpCurve>::const_iterator cit;
+  FapCurveStat cs;
 
-  for (cit = dataMap.begin(); cit != dataMap.end(); ++cit, ++sit)
-    if (cit->second.getCurveStatistics(wholeDomain, startT, stopT,
-				       scaledShifted,
-				       cit->first->getDFTparameters(),
-				       sit->second.rms, sit->second.avg,
-				       sit->second.stdDev, sit->second.integral,
-				       sit->second.min, sit->second.max, msg))
-      sit->first = cit->first;
+  for (const FapDataMap::value_type& cp : dataMap)
+    if (cp.second.getCurveStatistics(wholeDomain, startT, stopT, scaledShifted,
+                                     cp.first->getDFTparameters(),
+                                     cs.rms, cs.avg, cs.stdDev,
+                                     cs.integral, cs.min, cs.max, msg))
+      stat.emplace_back(cp.first,cs);
     else
     {
-      if (!msg.empty()) FFaMsg::dialog(msg,FFaMsg::DISMISS_ERROR);
+      if (!msg.empty())
+        FFaMsg::dialog(msg,FFaMsg::DISMISS_ERROR);
       return false;
     }
 

--- a/src/vpmApp/vpmAppDisplay/FapGraphDataMap.H
+++ b/src/vpmApp/vpmAppDisplay/FapGraphDataMap.H
@@ -17,16 +17,15 @@ class FFpSNCurve;
 
 struct FapCurveStat
 {
-  double rms;
-  double avg;
-  double stdDev;
-  double integral;
-  double min;
-  double max;
-  FapCurveStat() { rms = avg = stdDev = integral = min = max = 0.0; }
+  double rms = 0.0;
+  double avg = 0.0;
+  double stdDev = 0.0;
+  double integral = 0.0;
+  double min = 0.0;
+  double max = 0.0;
 };
 
-typedef std::pair<const FmCurveSet*,FapCurveStat> FapCurveSet;
+using FapCurveSet = std::pair<const FmCurveSet*,FapCurveStat>;
 
 
 /*!
@@ -44,6 +43,8 @@ typedef std::pair<const FmCurveSet*,FapCurveStat> FapCurveSet;
 
 class FapGraphDataMap
 {
+  using FapDataMap = std::map<const FmCurveSet*,FFpCurve>;
+
 public:
   FapGraphDataMap() {}
 
@@ -57,7 +58,7 @@ public:
   { return this->findPlottingData({curve},&msg,appnd); }
 
   bool findPlottingData(const std::vector<FmCurveSet*>& curves,
-		        std::string* errMsg = NULL, bool isAppending = false);
+                        std::string* errMsg = NULL, bool isAppending = false);
 
   FFpCurve* getFFpCurve(const FmCurveSet* curve,
 			bool scaleShift = true, bool createIfNone = false);
@@ -79,21 +80,23 @@ public:
   bool setDataChanged(const FmCurveSet* curve);
 
   void erase(const FmCurveSet* curve) { dataMap.erase(curve); }
-  void clear() { dataMap.clear(); }
+  void clear() { dataMap.clear(); compMap.clear(); }
 
 protected:
-  static void replaceCombinedCurves(std::vector<FmCurveSet*>& curves);
+  static void resolveCombinedCurves(std::vector<FmCurveSet*>& curves,
+                                    std::vector<FmCurveSet*>& cCurves);
 
-  static bool findDataFromFunc(const FmCurveSet* curve,
-			       FFpCurve& curveData, std::string& message);
+  static bool findDataFromFunc(const FmCurveSet* curve, FFpCurve& curveData,
+                               std::string& message);
 
-  static bool findDataFromFile(const FmCurveSet* curve,
-			       FFpCurve& curveData, std::string& message);
+  static bool findDataFromFile(const FmCurveSet* curve, FFpCurve& curveData,
+                               std::string& message);
 
   bool findCombinedCurveData(const FmCurveSet* curve, std::string& message);
 
 private:
-  std::map<const FmCurveSet*,FFpCurve> dataMap;
+  FapDataMap dataMap; //!< Curve data for the plotted curves
+  FapDataMap compMap; //!< Curve data for combined curve components
 };
 
 #endif

--- a/src/vpmApp/vpmAppUAMap/FapUASimModelListView.C
+++ b/src/vpmApp/vpmAppUAMap/FapUASimModelListView.C
@@ -29,7 +29,6 @@
 #include "vpmDB/FmSoilPile.H"
 #include "FFaLib/FFaCmdLineArg/FFaCmdLineArg.H"
 #include "FFaLib/FFaString/FFaStringExt.H"
-#include "FFaLib/FFaDefinitions/FFaAppInfo.H"
 
 
 //----------------------------------------------------------------------------
@@ -123,9 +122,9 @@ FFaListViewItem* FapUASimModelListView::getParent(FFaListViewItem* item,
 #endif
 
   FmModelMemberBase* mmb = dynamic_cast<FmModelMemberBase*>(item);
-  if (!mmb) return 0;
+  if (!mmb) return NULL;
 
-  FFaListViewItem* parent = 0;
+  FFaListViewItem* parent = NULL;
   if (mmb->isOfType(FmRingStart::getClassTypeID()))
   {
     parent = ((FmRingStart*)mmb)->getParent();
@@ -134,7 +133,7 @@ FFaListViewItem* FapUASimModelListView::getParent(FFaListViewItem* item,
         if (assID.back() != parent->getItemID())
         {
           std::cerr <<"ERROR: Assembly topology inconsistency detected!"<< std::endl;
-          parent = 0;
+          parent = NULL;
         }
   }
   else if (mmb->isOfType(FmElementGroupProxy::getClassTypeID()))
@@ -278,31 +277,19 @@ FFuaUICommands* FapUASimModelListView::getCommands()
 {
   FuaItemsLVCommands* cmds = new FuaItemsLVCommands();
 
-  // Clearing sub menu entries
-
-  this->createHeader.clear();
-  this->createSpringFunctionHeader.clear();
-  this->createDamperFunctionHeader.clear();
-  this->createFrictionHeader.clear();
-
   // Setting up sub menu command headers :
 
+  this->createHeader.clear();
   this->createHeader.setText("Create");
+  this->createSpringFunctionHeader.clear();
   this->createSpringFunctionHeader.setText("Spring characteristics");
   this->createSpringFunctionHeader.setSmallIcon(spring_xpm);
+  this->createDamperFunctionHeader.clear();
   this->createDamperFunctionHeader.setText("Damper characteristics");
   this->createDamperFunctionHeader.setSmallIcon(damper_xpm);
+  this->createFrictionHeader.clear();
   this->createFrictionHeader.setText("Friction");
   this->createFrictionHeader.setSmallIcon(friction_xpm);
-
-  this->convertHeader.setText("Convert function");
-  this->convertToSpringHeader.setText("Spring characteristics");
-  this->convertToSpringHeader.setSmallIcon(spring_xpm);
-  this->convertToDamperHeader.setText("Damper characteristics");
-  this->convertToDamperHeader.setSmallIcon(damper_xpm);
-
-  this->solveHeader.setText("Solve");
-  this->resultHeader.setText("Result");
 
   // Build menus
 
@@ -359,14 +346,19 @@ FFuaUICommands* FapUASimModelListView::getCommands()
 
   if (convertable) {
     this->convertHeader.clear();
-    this->convertToSpringHeader.clear();
-    this->convertToDamperHeader.clear();
-
+    this->convertHeader.setText("Convert function");
     cmds->popUpMenu.push_back(&this->separator);
     cmds->popUpMenu.push_back(&this->convertHeader);
 
     if (convertableSprDa) {
+      this->convertToSpringHeader.clear();
+      this->convertToSpringHeader.setText("Spring characteristics");
+      this->convertToSpringHeader.setSmallIcon(spring_xpm);
       this->convertHeader.push_back(&this->convertToSpringHeader);
+
+      this->convertToDamperHeader.clear();
+      this->convertToDamperHeader.setText("Damper characteristics");
+      this->convertToDamperHeader.setSmallIcon(damper_xpm);
       this->convertHeader.push_back(&this->convertToDamperHeader);
 
       this->convertToSpringHeader.push_back(FFuaCmdItem::getCmdItem("cmdId_function_ConvertSprTransStiff"));
@@ -420,10 +412,11 @@ FFuaUICommands* FapUASimModelListView::getCommands()
     cmds->popUpMenu.push_back(&this->solveHeader);
 
     this->solveHeader.clear();
-    if (!FFaAppInfo::checkProgramPath("fedem_partsol").empty())
-      this->solveHeader.push_back(FFuaCmdItem::getCmdItem("cmdId_solve_solveLink"));
+    this->solveHeader.setText("Solve");
+    this->solveHeader.push_back(FFuaCmdItem::getCmdItem("cmdId_solve_solveLink"));
     this->solveHeader.push_back(FFuaCmdItem::getCmdItem("cmdId_solve_reduceLink"));
     this->solveHeader.push_back(FFuaCmdItem::getCmdItem("cmdId_solve_solveStressOnLink"));
+    this->solveHeader.push_back(FFuaCmdItem::getCmdItem("cmdId_solve_solveModesOnLink"));
     this->solveHeader.push_back(FFuaCmdItem::getCmdItem("cmdId_solve_solveRosetteOnLink"));
     this->solveHeader.push_back(FFuaCmdItem::getCmdItem("cmdId_solve_solveStrainCoatOnLink"));
   }
@@ -437,6 +430,7 @@ FFuaUICommands* FapUASimModelListView::getCommands()
       cmds->popUpMenu.push_back(&this->resultHeader);
 
       this->resultHeader.clear();
+      this->resultHeader.setText("Result");
       this->resultHeader.push_back(FFuaCmdItem::getCmdItem("cmdId_dBCreate_beamForceGraph"));
     }
     if (isObjectOfTypeSelected(FmBladeDesign(true)))

--- a/src/vpmDisplay/FdFEGroupPartKit.C
+++ b/src/vpmDisplay/FdFEGroupPartKit.C
@@ -143,7 +143,7 @@ FdFEGroupPartKit::~FdFEGroupPartKit()
   this->deleteResultFrame(-1);
 }
 
-void FdFEGroupPartKit::setSpecialGraphics(SoSeparator * scene, bool isLineShape = false)
+void FdFEGroupPartKit::setSpecialGraphics(SoSeparator* scene, bool isLineShape)
 {
   this->setPart("specialGraphics", scene);
   this->setLineOffsetOn(!isLineShape);
@@ -387,7 +387,7 @@ void FdFEGroupPartKit::remapLookResults(ResultsFrame* frame, const FFaLegendMapp
 
   SoPackedColor* pc = frame->getResColors();
 
-  if (!myGroupPartData || myGroupPartData->isIndexShape)
+  if (!myGroupPartData || !myGroupPartData->shapeIndexes.empty())
   {
     pc->orderedRGBA.setNum(frame->resValues.size());
     uint32_t* packedColors = pc->orderedRGBA.startEditing();
@@ -481,7 +481,7 @@ float FdFEGroupPartKit::getResultFromMaterialIndex(unsigned int matIdx) const
 
   int resIdx = -1;
   ResultsFrame* frame = myResultFrames[myCurrentFrame];
-  if (!myGroupPartData || myGroupPartData->isIndexShape)
+  if (!myGroupPartData || !myGroupPartData->shapeIndexes.empty())
     resIdx = matIdx;
   else
     switch (frame->resLookPolicy)

--- a/src/vpmDisplay/FdFEModel.C
+++ b/src/vpmDisplay/FdFEModel.C
@@ -50,29 +50,29 @@ void FdFEModel::updateGroupParts(FFlGroupPartCreator* gpc)
   this->deleteVisualization(true);
   if (!gpc) return;
 
-  for (const FFlGroupPartCreator::GroupPartMap::value_type& gp : gpc->getLinkParts())
-    if (gp.second->isIndexShape && !gp.second->shapeIndexes.empty())
+  for (FFlGroupPartCreator::GroupPartMap::value_type& gp : *gpc)
+    if (!gp.second.shapeIndexes.empty())
     {
       FdFEGroupPart* fdGP = this->createGroupPart();
-      fdGP->setFaceIndexes(!gp.second->isLineShape,gp.second->shapeIndexes);
-      if (gp.second->isLineShape)
+      fdGP->setFaceIndexes(!gp.second.isLineShape,gp.second.shapeIndexes);
+      if (gp.second.isLineShape)
         fdGP->setLinePattern(0xffff);
-      gp.second->visualModel = fdGP;
+      gp.second.visualModel = fdGP;
       myGroupParts[gp.first].push_back(fdGP);
     }
-    else if (!gp.second->facePointers.empty() || !gp.second->hiddenFaces.empty() ||
-             !gp.second->edgePointers.empty() || !gp.second->hiddenEdges.empty())
+    else if (!gp.second.facePointers.empty() || !gp.second.hiddenFaces.empty() ||
+             !gp.second.edgePointers.empty() || !gp.second.hiddenEdges.empty())
     {
       FdFEGroupPart* fdGP = this->createGroupPart();
-      fdGP->setGroupPartData(gp.second);
+      fdGP->setGroupPartData(&gp.second);
       myGroupParts[gp.first].push_back(fdGP);
     }
 
-  for (const FFlGroupPartCreator::GroupPartMap::value_type& gp : gpc->getSpecialLines())
-    if (!gp.second->edgePointers.empty())
+  for (FFlGroupPartCreator::GroupPartMap::value_type& gp : gpc->getSpecialLines())
+    if (!gp.second.edgePointers.empty())
     {
       FdFEGroupPart* fdGP = this->createGroupPart();
-      fdGP->setGroupPartData(gp.second,gp.first);
+      fdGP->setGroupPartData(&gp.second,gp.first);
       myGroupParts[FFlGroupPartCreator::SPECIAL_LINES].push_back(fdGP);
     }
 
@@ -86,7 +86,7 @@ void FdFEModel::addGroupPart(FdFEGroupPartSet::GroupPartType type,
   if (!groupPartData)
     return;
 
-  if (groupPartData->isIndexShape && !groupPartData->shapeIndexes.empty())
+  if (!groupPartData->shapeIndexes.empty())
   {
     FdFEGroupPart* newFdGP = this->createGroupPart();
     newFdGP->setFaceIndexes(!groupPartData->isLineShape,

--- a/src/vpmDisplay/FdPart.C
+++ b/src/vpmDisplay/FdPart.C
@@ -207,8 +207,8 @@ bool FdPart::updateSpecialLines(double scale)
   myFEKit->deleteGroupParts(FdFEGroupPartSet::SPECIAL_LINES);
   myFEKit->updateVertexes(static_cast<FmPart*>(itsFmOwner)->getLinkHandler());
 
-  for (const FFlGroupPartCreator::GroupPartMap::value_type& gp : myGroupPartCreator->getSpecialLines())
-    myFEKit->addGroupPart(FdFEGroupPartSet::SPECIAL_LINES,gp.second);
+  for (FFlGroupPartCreator::GroupPartMap::value_type& gp : myGroupPartCreator->getSpecialLines())
+    myFEKit->addGroupPart(FdFEGroupPartSet::SPECIAL_LINES,&gp.second);
 
   return true;
 }

--- a/src/vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtCurveDefine.C
+++ b/src/vpmUI/vpmUIComponents/vpmUIQtComponents/FuiQtCurveDefine.C
@@ -214,9 +214,10 @@ FuiQtCurveDefSheet::FuiQtCurveDefSheet(const char* name)
 
 void FuiQtCurveDefSheet::setNoComps(unsigned int nc)
 {
+  if (nc <= curveComps.size()) return;
+
   char label[3] = "A:";
-  if (!curveComps.empty())
-    label[0] += curveComps.size()-1;
+  label[0] += curveComps.size();
 
   QLayout* layout = combFrame->getQtWidget()->layout();
 


### PR DESCRIPTION
This fixes #148. The problem was that when one of the component curves was toggled for Differentiation (or integration, or DFT-transformation). This curve was differentiated again when the combined curve using it was reloaded because its Differentiate-toggle was enabled. The fix is to reset the dataChanged flag of the curve data, which will then skip the transformation until the data is changed or reloaded.